### PR TITLE
fix issue pillar-markup/pillar#352

### DIFF
--- a/src/Pillar-ExporterCore.package/PRDocumentWriter.class/instance/write.to..st
+++ b/src/Pillar-ExporterCore.package/PRDocumentWriter.class/instance/write.to..st
@@ -1,3 +1,3 @@
 visiting
 write: aDocumentItem to: aStream
-	^ self setStream: aStream; start: aDocumentItem; contents
+	^ self setStream: aStream; start: aDocumentItem

--- a/src/Pillar-ExporterCore.package/PRExportCanvas.class/instance/nextPut..st
+++ b/src/Pillar-ExporterCore.package/PRExportCanvas.class/instance/nextPut..st
@@ -1,3 +1,3 @@
 writing text
 nextPut: aCharacter
-	stream << aCharacter
+	stream nextPut: aCharacter

--- a/src/Pillar-ExporterCore.package/PROutputStream.class/instance/nextPut..st
+++ b/src/Pillar-ExporterCore.package/PROutputStream.class/instance/nextPut..st
@@ -1,0 +1,3 @@
+accessing
+nextPut: aCharacter 
+	stream nextPut: aCharacter

--- a/src/Pillar-ExporterHTML.package/PRHTMLTag.class/instance/name..st
+++ b/src/Pillar-ExporterHTML.package/PRHTMLTag.class/instance/name..st
@@ -1,4 +1,4 @@
 accessing
 name: aString
 	name := aString.
-	stream << $< << aString
+	stream nextPut: $<; << aString

--- a/src/Pillar-ExporterHTML.package/PRHTMLTag.class/instance/with..st
+++ b/src/Pillar-ExporterHTML.package/PRHTMLTag.class/instance/with..st
@@ -1,3 +1,8 @@
 accessing
 with: aString
-	stream << $> << aString << '</' << name << $>
+	stream 
+		nextPut: $>; 
+		<< aString;
+		<< '</'; 
+		<< name;
+		nextPut: $>

--- a/src/Pillar-Tests-ExporterHTML.package/PRHTMLWriterTest.class/instance/testHeaderOne.st
+++ b/src/Pillar-Tests-ExporterHTML.package/PRHTMLWriterTest.class/instance/testHeaderOne.st
@@ -1,0 +1,15 @@
+tests
+testHeaderOne
+
+	| aNode aContents |
+	aNode := PRHeader new 
+		level: 1;
+		add: (PRText new text: 'Header One').
+
+	aContents := (FileReference newTempFilePrefix: 'a' suffix: 'b')
+		writeStreamDo: [ :writeStream | 
+			PRHTMLWriter new write: aNode to: writeStream ];
+		contents.
+		
+	self assert: aContents equals: '<h1>Header One</h1>
+'


### PR DESCRIPTION
tested on 

```
aNode := PRHeader new 
	level: 1;
	add: (PRText new text: 'Header One').

(FileReference newTempFilePrefix: 'a' suffix: 'b')
 writeStreamDo: [ :writeStream | 
PRHTMLWriter new write: aNode to: writeStream ];
	contents
```
