### PR TITLE
Fix AST node start and stop values

### DIFF
--- a/src/BaselineOfPillarCore/BaselineOfPillarCore.class.st
+++ b/src/BaselineOfPillarCore/BaselineOfPillarCore.class.st
@@ -1,0 +1,30 @@
+Class {
+	#name : #BaselineOfPillarCore,
+	#superclass : #BaselineOf,
+	#category : #BaselineOfPillarCore
+}
+
+{ #category : #baselines }
+BaselineOfPillarCore >> baseline: spec [
+	<baseline>
+
+	spec
+		for: #common
+		do: [ spec blessing: #baseline.
+			spec 
+				baseline: 'ContainersPropertyEnvironment' with: [ spec 
+					repository: 'github://feenkcom/Containers-PropertyEnvironment' ];
+				baseline: 'PetitParser2Core' with: [ spec
+					 repository: 'github://kursjan/petitparser2' ];
+
+				package: 'Pillar-Model';
+				package: 'Pillar-PetitPillar' with: [ spec 
+					requires: #( 'PetitParser2Core' 'Pillar-Model' ) ];
+				"package: 'Pillar-Tests-Model' with: [ spec 
+					requires: #('Pillar-Model' 'Pillar-ExporterPilar' 'Pillar-ExporterText') ];"
+				package: 'Pillar-Tests-PetitPillar' with: [ spec 
+					requires: #( 'Pillar-PetitPillar' )  ]
+					
+	]
+
+]

--- a/src/BaselineOfPillarCore/BaselineOfPillarCore.class.st
+++ b/src/BaselineOfPillarCore/BaselineOfPillarCore.class.st
@@ -13,7 +13,7 @@ BaselineOfPillarCore >> baseline: spec [
 		do: [ spec blessing: #baseline.
 			spec 
 				baseline: 'ContainersPropertyEnvironment' with: [ spec 
-					repository: 'github://feenkcom/Containers-PropertyEnvironment' ];
+					repository: 'github://Ducasse/Containers-PropertyEnvironment' ];
 				baseline: 'PetitParser2Core' with: [ spec
 					 repository: 'github://kursjan/petitparser2' ];
 

--- a/src/BaselineOfPillarCore/package.st
+++ b/src/BaselineOfPillarCore/package.st
@@ -1,0 +1,1 @@
+Package { #name : #BaselineOfPillarCore }

--- a/src/BaselineOfPillarExporter/BaselineOfPillarExporter.class.st
+++ b/src/BaselineOfPillarExporter/BaselineOfPillarExporter.class.st
@@ -37,7 +37,7 @@ BaselineOfPillarExporter >> baseline: spec [
 				package: 'Pillar-ExporterHTML' with: [ spec requires: #('Pillar-ExporterCore') ];
 				package: 'Pillar-ExporterLaTeX' with: [ spec requires: #('Pillar-ExporterCore' 'Pillar-ExporterPillar') ];
 				package: 'Pillar-ExporterMarkdown' with: [ spec requires: #('Pillar-ExporterCore' 'Pillar-ExporterHTML') ];
-				package: 'Pillar-ExporterPillar' with: [ spec requires: #('Pillar-ExporterCore' 'Pillar-PetitPillar') ];
+				package: 'Pillar-ExporterPillar' with: [ spec requires: #('Pillar-ExporterCore' 'PillarCore') ];
 				package: 'Pillar-ExporterText' with: [ spec requires: #('Pillar-ExporterCore') ];
 
 				package: 'Pillar-Tests-ExporterAsciiDoc'
@@ -75,8 +75,6 @@ BaselineOfPillarExporter >> baseline: spec [
 				group: 'latex exporter tests' with: #('Pillar-Tests-ExporterLaTeX');
 				group: 'markdown exporter' with: #('Pillar-ExporterMarkdown' 'parser');
 				group: 'markdown exporter tests' with: #('Pillar-Tests-ExporterMarkdown');
-				group: 'parser' with: #('Pillar-PetitPillar');
-				group: 'parser tests' with: #('Pillar-Tests-PetitPillar');
 				group: 'pillar exporter' with: #('Pillar-ExporterPillar');
 				group: 'pillar exporter tests' with: #('Pillar-Tests-ExporterPillar');
 				group: 'text exporter' with: #('Pillar-ExporterText');

--- a/src/BaselineOfPillarExporter/BaselineOfPillarExporter.class.st
+++ b/src/BaselineOfPillarExporter/BaselineOfPillarExporter.class.st
@@ -73,7 +73,7 @@ BaselineOfPillarExporter >> baseline: spec [
 				group: 'html exporter tests' with: #('Pillar-Tests-ExporterHTML');
 				group: 'latex exporter' with: #('Pillar-ExporterLaTeX');
 				group: 'latex exporter tests' with: #('Pillar-Tests-ExporterLaTeX');
-				group: 'markdown exporter' with: #('Pillar-ExporterMarkdown' 'parser');
+				group: 'markdown exporter' with: #('Pillar-ExporterMarkdown' 'PillarCore');
 				group: 'markdown exporter tests' with: #('Pillar-Tests-ExporterMarkdown');
 				group: 'pillar exporter' with: #('Pillar-ExporterPillar');
 				group: 'pillar exporter tests' with: #('Pillar-Tests-ExporterPillar');

--- a/src/BaselineOfPillarExporter/BaselineOfPillarExporter.class.st
+++ b/src/BaselineOfPillarExporter/BaselineOfPillarExporter.class.st
@@ -1,0 +1,86 @@
+Class {
+	#name : #BaselineOfPillarExporter,
+	#superclass : #BaselineOf,
+	#category : #BaselineOfPillarExporter
+}
+
+{ #category : #baselines }
+BaselineOfPillarExporter >> baseline: spec [
+	<baseline>
+
+	spec
+		for: #common
+		do: [ spec blessing: #baseline.
+			spec 
+				baseline: 'PillarCore' with: [ spec 
+					repository: 'github://feenkcom/pillar:feenk/src' ];
+				baseline: 'Chrysal' with: [ spec 
+					repository: 'github://feenkcom/Chrysal/src' ];
+				baseline: 'Mustache' with: [ spec
+					repository: 'github://noha/mustache:v1.0/repository';
+					loads: #('Core' 'Tests') ];
+				
+				package: 'Pillar-Chrysal-Generator' with: [ spec 
+					requires: #( 'PillarCore' 'Chrysal') ];
+				package: 'Pillar-Chrysal' with: [ spec 
+					requires: #( 'PillarCore' "'Pillar-ExporterCore'" ) ];
+				"Pillar-Chrysal should only depend on Chrysal-Runtime 
+				but right now I do not know how to express that the Chrysal (builder) 
+				is different from Chrysal-Runtime"
+				
+				package: 'Pillar-ExporterCore' with: [ spec 
+					requires: #( 'PillarCore' 'Mustache' 'Pillar-Chrysal' ) ];
+				package: 'Pillar-ExporterAsciiDoc' with: [ spec requires: #('Pillar-ExporterCore') ];
+				package: 'Pillar-ExporterBeamer' with: [ spec requires: #('Pillar-ExporterLaTeX') ];
+				package: 'Pillar-ExporterDeckJS' with: [ spec requires: #('Pillar-ExporterHTML') ];
+				package: 'Pillar-ExporterEPub' with: [ spec requires: #('Pillar-ExporterCore' 'Pillar-ExporterHTML') ];
+				package: 'Pillar-ExporterHTML' with: [ spec requires: #('Pillar-ExporterCore') ];
+				package: 'Pillar-ExporterLaTeX' with: [ spec requires: #('Pillar-ExporterCore' 'Pillar-ExporterPillar') ];
+				package: 'Pillar-ExporterMarkdown' with: [ spec requires: #('Pillar-ExporterCore' 'Pillar-ExporterHTML') ];
+				package: 'Pillar-ExporterPillar' with: [ spec requires: #('Pillar-ExporterCore' 'Pillar-PetitPillar') ];
+				package: 'Pillar-ExporterText' with: [ spec requires: #('Pillar-ExporterCore') ];
+
+				package: 'Pillar-Tests-ExporterAsciiDoc'
+					with: [ spec requires: #('Pillar-ExporterAsciiDoc' 'Pillar-Tests-ExporterCore') ];
+				package: 'Pillar-Tests-ExporterBeamer' with: [ spec requires: #('Pillar-ExporterBeamer' 'Pillar-Tests-ExporterLaTeX') ];
+				package: 'Pillar-Tests-ExporterCore' with: [ spec requires: #('Pillar-Tests-Model' 'Pillar-ExporterCore') ];
+				package: 'Pillar-Tests-ExporterDeckJS' with: [ spec requires: #('Pillar-ExporterDeckJS' 'Pillar-Tests-ExporterHTML') ];
+				package: 'Pillar-Tests-ExporterEPub' with: [ spec requires: #(#'Pillar-ExporterEPub' 'Pillar-Tests-ExporterCore') ];
+				package: 'Pillar-Tests-ExporterHTML' with: [ spec requires: #('Pillar-ExporterHTML' 'Pillar-Tests-ExporterCore') ];
+				package: 'Pillar-Tests-ExporterLaTeX' with: [ spec requires: #('Pillar-ExporterLaTeX' 'Pillar-Tests-ExporterCore') ];
+				package: 'Pillar-Tests-ExporterMarkdown'
+					with: [ spec requires: #('Pillar-ExporterMarkdown' 'Pillar-Tests-ExporterCore' 'Pillar-Tests-ExporterHTML') ];
+				package: 'Pillar-Tests-ExporterPillar' with: [ spec requires: #('Pillar-ExporterPillar' 'Pillar-Tests-ExporterCore') ];
+				package: 'Pillar-Tests-ExporterText' with: [ spec requires: #('Pillar-ExporterText' 'Pillar-Tests-ExporterCore') ];
+				
+				"Pillar-Tests-Model should be in core, but has many exporter dependencies"
+				package: 'Pillar-Tests-Model' with: [ spec requires: #('PillarCore' 'Pillar-ExporterPillar' 'Pillar-ExporterText') ].
+				
+					
+		spec
+				group: 'All exporters'
+					with:
+					#('html exporter' 'latex exporter' 'beamer exporter' 'deckjs exporter' 'markdown exporter' 'pillar exporter' 'text exporter' 'asciidoc exporter' 'ePub exporter');
+				group: 'asciidoc exporter' with: #(#'Pillar-ExporterAsciiDoc');
+				group: 'asciidoc exporter tests' with: #(#'Pillar-Tests-ExporterAsciiDoc' 'ePub exporter');
+				group: 'beamer exporter' with: #('Pillar-ExporterBeamer');
+				group: 'beamer exporter tests' with: #('Pillar-Tests-ExporterBeamer');
+				group: 'deckjs exporter' with: #('Pillar-ExporterDeckJS');
+				group: 'deckjs exporter tests' with: #('Pillar-Tests-ExporterDeckJS');
+				group: 'ePub exporter' with: #(#'Pillar-ExporterEPub');
+				group: 'ePub exporter tests' with: #(#'Pillar-Tests-ExporterEPub');
+				group: 'html exporter' with: #('Pillar-ExporterHTML');
+				group: 'html exporter tests' with: #('Pillar-Tests-ExporterHTML');
+				group: 'latex exporter' with: #('Pillar-ExporterLaTeX');
+				group: 'latex exporter tests' with: #('Pillar-Tests-ExporterLaTeX');
+				group: 'markdown exporter' with: #('Pillar-ExporterMarkdown' 'parser');
+				group: 'markdown exporter tests' with: #('Pillar-Tests-ExporterMarkdown');
+				group: 'parser' with: #('Pillar-PetitPillar');
+				group: 'parser tests' with: #('Pillar-Tests-PetitPillar');
+				group: 'pillar exporter' with: #('Pillar-ExporterPillar');
+				group: 'pillar exporter tests' with: #('Pillar-Tests-ExporterPillar');
+				group: 'text exporter' with: #('Pillar-ExporterText');
+				group: 'text exporter tests' with: #('Pillar-Tests-ExporterText').
+	]
+
+]

--- a/src/BaselineOfPillarExporter/BaselineOfPillarExporter.class.st
+++ b/src/BaselineOfPillarExporter/BaselineOfPillarExporter.class.st
@@ -15,7 +15,7 @@ BaselineOfPillarExporter >> baseline: spec [
 				baseline: 'PillarCore' with: [ spec 
 					repository: 'github://feenkcom/pillar:feenk/src' ];
 				baseline: 'Chrysal' with: [ spec 
-					repository: 'github://feenkcom/Chrysal/src' ];
+					repository: 'github://Ducasse/Chrysal/src' ];
 				baseline: 'Mustache' with: [ spec
 					repository: 'github://noha/mustache:v1.0/repository';
 					loads: #('Core' 'Tests') ];

--- a/src/BaselineOfPillarExporter/BaselineOfPillarExporter.class.st
+++ b/src/BaselineOfPillarExporter/BaselineOfPillarExporter.class.st
@@ -13,7 +13,7 @@ BaselineOfPillarExporter >> baseline: spec [
 		do: [ spec blessing: #baseline.
 			spec 
 				baseline: 'PillarCore' with: [ spec 
-					repository: 'github://feenkcom/pillar:feenk/src' ];
+					repository: 'github://pillar-markup/pillar:dev-7/src' ];
 				baseline: 'Chrysal' with: [ spec 
 					repository: 'github://Ducasse/Chrysal/src' ];
 				baseline: 'Mustache' with: [ spec

--- a/src/BaselineOfPillarExporter/package.st
+++ b/src/BaselineOfPillarExporter/package.st
@@ -1,0 +1,1 @@
+Package { #name : #BaselineOfPillarExporter }

--- a/src/Pillar-ExporterCore/RelativePath.extension.st
+++ b/src/Pillar-ExporterCore/RelativePath.extension.st
@@ -1,6 +1,6 @@
 Extension { #name : #RelativePath }
 
-{ #category : #'*Pillar-Project' }
+{ #category : #'*Pillar-ExporterCore' }
 RelativePath >> pillarPrintString [
 	self isEmpty ifTrue: [ ^ '' ].
 	^ String streamContents: [ :str |

--- a/src/Pillar-ExporterHTML/PRDocumentListTransformer.class.st
+++ b/src/Pillar-ExporterHTML/PRDocumentListTransformer.class.st
@@ -16,7 +16,7 @@ Class {
 		'filesDirectory',
 		'availableTemplates'
 	],
-	#category : 'Pillar-ExporterCore-Document-List'
+	#category : #'Pillar-ExporterHTML'
 }
 
 { #category : #'instance-creation' }

--- a/src/Pillar-ExporterHTML/PRHTMLEmptyTag.class.st
+++ b/src/Pillar-ExporterHTML/PRHTMLEmptyTag.class.st
@@ -30,7 +30,7 @@ PRHTMLEmptyTag >> closeTag [
 { #category : #accessing }
 PRHTMLEmptyTag >> name: aString [
 	name := aString.
-	stream << $< << aString
+	stream nextPut: $<; << aString
 ]
 
 { #category : #accessing }

--- a/src/Pillar-Model/PRAbstractAnnotation.class.st
+++ b/src/Pillar-Model/PRAbstractAnnotation.class.st
@@ -144,21 +144,6 @@ PRAbstractAnnotation class >> validateParameters: aPRParameters dictionary: para
 				ifTrue: [ PRValidation strategy unexpectedParameterIn: anAnnotation ] ]
 ]
 
-{ #category : #'instance creation' }
-PRAbstractAnnotation class >> withParameters: aPRParameters [
-	| parameters anInstance |
-	anInstance := self with: aPRParameters.
-	PRParserUtility fixFirstParameter: aPRParameters for: anInstance.
-	parameters := PRParametersToOrderedDictionary of: aPRParameters.
-	self validateParameters: aPRParameters dictionary: parameters in: anInstance.
-	^ anInstance
-		hadAllKeys:
-			(self possibleParameters
-				difference: (parameters keys collect: #asSymbol)) isEmpty;
-		parameters: parameters;
-		yourself
-]
-
 { #category : #comparing }
 PRAbstractAnnotation >> = anObject [
 	^ super = anObject and: [ 

--- a/src/Pillar-Model/PRDocumentListAnnotation.class.st
+++ b/src/Pillar-Model/PRDocumentListAnnotation.class.st
@@ -17,7 +17,7 @@ ${docList:path=wrongDirectory|limit=3|sort=date|templates=#('templates/docArticl
 Class {
 	#name : #PRDocumentListAnnotation,
 	#superclass : #PRAbstractAnnotation,
-	#category : 'Pillar-Model-Document-List'
+	#category : #'Pillar-Model-Document'
 }
 
 { #category : #protected }

--- a/src/Pillar-Model/PRMockAnnotation.class.st
+++ b/src/Pillar-Model/PRMockAnnotation.class.st
@@ -1,0 +1,47 @@
+"
+I am a Mock to test the annotations.
+"
+Class {
+	#name : #PRMockAnnotation,
+	#superclass : #PRAbstractAnnotation,
+	#category : #'Pillar-Model-Document'
+}
+
+{ #category : #'instance creation' }
+PRMockAnnotation class >> possibleParameters [
+
+	^ #(value number)
+]
+
+{ #category : #protected }
+PRMockAnnotation class >> tag [
+	^ #mock
+]
+
+{ #category : #'instance creation' }
+PRMockAnnotation class >> validateParameters: parameters [
+
+	super validateParameters: parameters.
+	parameters
+		at: 'number'
+		ifPresent: [ :v | parameters at: 'number' put: v asNumber ]
+	
+]
+
+{ #category : #'instance creation' }
+PRMockAnnotation class >> validateParameters: aPRParameters dictionary: parametersDictionary in: anAnnotation [
+	super
+		validateParameters: aPRParameters
+		dictionary: parametersDictionary
+		in: anAnnotation.
+	parametersDictionary
+		at: 'number'
+		ifPresent: [ :v | parametersDictionary at: 'number' put: v asNumber ]
+]
+
+{ #category : #printing }
+PRMockAnnotation >> asPillarParametersOn: aStream [
+	self parameters keys
+		do: [ :each | self asPillarKey: each value:  (self parameters at: each asString) asString on: aStream ]
+		separatedBy: [ aStream nextPut: self class parameterSeparator ]
+]

--- a/src/Pillar-Model/PRParagraph.class.st
+++ b/src/Pillar-Model/PRParagraph.class.st
@@ -14,22 +14,6 @@ PRParagraph class >> isAbstract [
 	^ false
 ]
 
-{ #category : #testing }
-PRParagraph class >> paragraphWithOtherMarkups [
-	<sampleInstance>
-	
-	^ PRPillarParser parse: 'Here is a list of publications
-	
-${publications:Ducasse|bibFile=rmod.bib}$
-The paragraph continues here.
-- a
-- b
-[[[
-a test  
-]]]
-You can contact me if you want.'
-]
-
 { #category : #visiting }
 PRParagraph >> accept: aVisitor [
 	aVisitor visitParagraph: self

--- a/src/Pillar-PetitPillar/PRAbstractAnnotation.extension.st
+++ b/src/Pillar-PetitPillar/PRAbstractAnnotation.extension.st
@@ -1,0 +1,16 @@
+Extension { #name : #PRAbstractAnnotation }
+
+{ #category : #'*Pillar-PetitPillar' }
+PRAbstractAnnotation class >> withParameters: aPRParameters [
+	| parameters anInstance |
+	anInstance := self with: aPRParameters.
+	PRParserUtility fixFirstParameter: aPRParameters for: anInstance.
+	parameters := PRParametersToOrderedDictionary of: aPRParameters.
+	self validateParameters: aPRParameters dictionary: parameters in: anInstance.
+	^ anInstance
+		hadAllKeys:
+			(self possibleParameters
+				difference: (parameters keys collect: #asSymbol)) isEmpty;
+		parameters: parameters;
+		yourself
+]

--- a/src/Pillar-PetitPillar/PRParagraph.extension.st
+++ b/src/Pillar-PetitPillar/PRParagraph.extension.st
@@ -1,0 +1,17 @@
+Extension { #name : #PRParagraph }
+
+{ #category : #'*Pillar-PetitPillar' }
+PRParagraph class >> paragraphWithOtherMarkups [
+	<sampleInstance>
+	
+	^ PRPillarParser parse: 'Here is a list of publications
+	
+${publications:Ducasse|bibFile=rmod.bib}$
+The paragraph continues here.
+- a
+- b
+[[[
+a test  
+]]]
+You can contact me if you want.'
+]

--- a/src/Pillar-PetitPillar/PRPillarGrammar.class.st
+++ b/src/Pillar-PetitPillar/PRPillarGrammar.class.st
@@ -298,7 +298,11 @@ PRPillarGrammar >> annotationMarkupSeparator [
 
 { #category : #'grammar - Annotation' }
 PRPillarGrammar >> annotationParameters [
-	^ (annotationMarkupSeparator , parametersUntilEndAnnotation) ==> [ :array | array second ]
+	^	epsilonToken , 	
+		annotationMarkupSeparator ,
+		epsilonToken , 
+		parametersUntilEndAnnotation, 
+		epsilonToken
 ]
 
 { #category : #'grammar - Annotation' }

--- a/src/Pillar-PetitPillar/PRPillarGrammar.class.st
+++ b/src/Pillar-PetitPillar/PRPillarGrammar.class.st
@@ -391,7 +391,9 @@ PRPillarGrammar >> elementsAtLineBeginning [
 
 { #category : #'grammar - Paragraph' }
 PRPillarGrammar >> emptyParagraph [
-	^ newline
+	^ epsilonToken , 
+		newline , 
+		epsilonToken 
 ]
 
 { #category : #'grammar - Helper' }

--- a/src/Pillar-PetitPillar/PRPillarGrammar.class.st
+++ b/src/Pillar-PetitPillar/PRPillarGrammar.class.st
@@ -496,7 +496,11 @@ PRPillarGrammar >> link [
 
 { #category : #'grammar - Reference' }
 PRPillarGrammar >> linkAlias [
-	^ ((escapedCharacter / (linkMarkup / referenceAliasMarkup) negate) star flatten, referenceAliasMarkup) ==> #first
+	^ 	epsilonToken , 
+		(escapedCharacter / 
+			(linkMarkup / referenceAliasMarkup) negate) star flatten , 
+		epsilonToken ,
+		referenceAliasMarkup
 ]
 
 { #category : #'grammar - Reference' }

--- a/src/Pillar-PetitPillar/PRPillarGrammar.class.st
+++ b/src/Pillar-PetitPillar/PRPillarGrammar.class.st
@@ -417,7 +417,11 @@ PRPillarGrammar >> figure [
 
 { #category : #'grammar - Reference' }
 PRPillarGrammar >> figureAlias [
-	^ ((escapedCharacter / (figureMarkup / referenceAliasMarkup) negate) star flatten, referenceAliasMarkup) ==> #first
+	^ 	epsilonToken ,
+		(escapedCharacter / 
+			(figureMarkup / referenceAliasMarkup) negate) star flatten , 
+		epsilonToken ,
+		referenceAliasMarkup
 ]
 
 { #category : #'grammar - Reference' }

--- a/src/Pillar-PetitPillar/PRPillarParser.class.st
+++ b/src/Pillar-PetitPillar/PRPillarParser.class.st
@@ -228,12 +228,11 @@ PRPillarParser >> link [
 
 { #category : #'grammar - Reference' }
 PRPillarParser >> linkAlias [
-	^ super linkAlias
-		==>
-			[ :string | 
-			string
-				ifEmpty: [ {(PRText content: '')} ]
-				ifNotEmpty: [ self parse: string startingAt: #oneLineContent ] ]
+	^ super linkAlias ==> [ :anArray | 
+			anArray second
+				ifEmpty: [ { (PRText content: '') start: anArray first start; stop: anArray first start } ]
+				ifNotEmpty: [ 
+					self parse: anArray second startingAt: #oneLineContent ] ]
 ]
 
 { #category : #helpers }
@@ -633,7 +632,7 @@ PRPillarParser >> text [
 	^ super text ==> [ :array | 
 			(PRText content: (self stringFrom: array second))
 				start: array first start;
-				stop: array third stop ]
+				stop: array third start ]
 ]
 
 { #category : #'grammar - Format' }

--- a/src/Pillar-PetitPillar/PRPillarParser.class.st
+++ b/src/Pillar-PetitPillar/PRPillarParser.class.st
@@ -158,12 +158,15 @@ PRPillarParser >> figure [
 
 { #category : #'grammar - Reference' }
 PRPillarParser >> figureAlias [
-	^ super figureAlias
-		==>
-			[ :string | 
-			string
-				ifEmpty: [ {(PRText content: '')} ]
-				ifNotEmpty: [ self parse: string startingAt: #oneLineContent ] ]
+	^ super figureAlias ==> [ :anArray | 
+			anArray second
+				ifEmpty: [ { (PRText content: '') start: anArray first start; stop: anArray first start } ]
+				ifNotEmpty: [ 
+					| aCollection |
+					aCollection := (self parse: anArray second startingAt: #oneLineContent).
+					aCollection do: [ :each | 
+						each start: each start + anArray first start - 1.
+						each stop: each stop + anArray first start - 1 ] ] ]
 ]
 
 { #category : #'from markdown' }
@@ -236,7 +239,7 @@ PRPillarParser >> linkAlias [
 					aCollection := (self parse: anArray second startingAt: #oneLineContent).
 					aCollection do: [ :each | 
 						each start: each start + anArray first start - 1.
-						each stop: each start + anArray second size - 1 ] ] ]
+						each stop: each stop + anArray first start - 1 ] ] ]
 ]
 
 { #category : #helpers }
@@ -638,7 +641,7 @@ PRPillarParser >> text [
 	^ super text ==> [ :array | 
 			(PRText content: (self stringFrom: array second))
 				start: array first start;
-				stop: array third start ]
+				stop: array third start - 1 ]
 ]
 
 { #category : #'grammar - Format' }

--- a/src/Pillar-PetitPillar/PRPillarParser.class.st
+++ b/src/Pillar-PetitPillar/PRPillarParser.class.st
@@ -232,7 +232,11 @@ PRPillarParser >> linkAlias [
 			anArray second
 				ifEmpty: [ { (PRText content: '') start: anArray first start; stop: anArray first start } ]
 				ifNotEmpty: [ 
-					self parse: anArray second startingAt: #oneLineContent ] ]
+					| aCollection |
+					aCollection := (self parse: anArray second startingAt: #oneLineContent).
+					aCollection do: [ :each | 
+						each start: each start + anArray first start - 1.
+						each stop: each start + anArray second size - 1 ] ] ]
 ]
 
 { #category : #helpers }

--- a/src/Pillar-PetitPillar/PRPillarParser.class.st
+++ b/src/Pillar-PetitPillar/PRPillarParser.class.st
@@ -429,7 +429,9 @@ PRPillarParser >> parametersLink [
 
 { #category : #'grammar - Parameter' }
 PRPillarParser >> parametersObjectFrom: array [
-	^ PRParameters with: array first withAll: array second
+	^ (PRParameters with: array fourth first withAll: array fourth second)
+			start: array third start;
+			stop: array fifth stop
 ]
 
 { #category : #'grammar - Parameter' }

--- a/src/Pillar-PetitPillar/PRPillarParser.class.st
+++ b/src/Pillar-PetitPillar/PRPillarParser.class.st
@@ -142,7 +142,8 @@ PRPillarParser >> document [
 
 { #category : #'grammar - Paragraph' }
 PRPillarParser >> emptyParagraph [
-	^ super emptyParagraph ==> [ :array | PREmptyParagraph new ]
+	^ super emptyParagraph ==> [ :array |
+		PREmptyParagraph new start: array first start; stop: array third stop ]
 ]
 
 { #category : #'grammar - Reference' }

--- a/src/Pillar-Tests-ExporterCore/PRSectionTransformerTest.class.st
+++ b/src/Pillar-Tests-ExporterCore/PRSectionTransformerTest.class.st
@@ -139,23 +139,3 @@ PRSectionTransformerTest >> testTransformWithoutSection [
 		yourself.
 	self assert: (self executePhase: input with: self configuration) equals: input
 ]
-
-{ #category : #tests }
-PRSectionTransformerTest >> testTransformationKeepSameContent [
-	| input |
-	input := PRDocument new
-		add:
-			(PRHeader new
-				level: 1;
-				add: (PRText content: 'Bar') yourself);
-		add: (PRParagraph with: (PRText content: 'Foo') yourself);
-		add:
-			(PRHeader new
-				level: 2;
-				add: (PRText content: 'Bar2') yourself);
-		add: (PRParagraph with: (PRText content: 'Foo2') yourself);
-		yourself.
-	self
-		assert: (PRPillarWriter write: (self executePhase: input with: self configuration))
-		equals: (PRPillarWriter write: input)
-]

--- a/src/Pillar-Tests-ExporterPillar/PRSectionTransformerTest.extension.st
+++ b/src/Pillar-Tests-ExporterPillar/PRSectionTransformerTest.extension.st
@@ -1,0 +1,21 @@
+Extension { #name : #PRSectionTransformerTest }
+
+{ #category : #'*Pillar-Tests-ExporterPillar' }
+PRSectionTransformerTest >> testTransformationKeepSameContent [
+	| input |
+	input := PRDocument new
+		add:
+			(PRHeader new
+				level: 1;
+				add: (PRText content: 'Bar') yourself);
+		add: (PRParagraph with: (PRText content: 'Foo') yourself);
+		add:
+			(PRHeader new
+				level: 2;
+				add: (PRText content: 'Bar2') yourself);
+		add: (PRParagraph with: (PRText content: 'Foo2') yourself);
+		yourself.
+	self
+		assert: (PRPillarWriter write: (self executePhase: input with: self configuration))
+		equals: (PRPillarWriter write: input)
+]

--- a/src/Pillar-Tests-ExporterText/PRTemplatedWriterTest.class.st
+++ b/src/Pillar-Tests-ExporterText/PRTemplatedWriterTest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #PRTemplatedWriterTest,
 	#superclass : #TestCase,
-	#category : 'Pillar-Tests-ExporterCore-LevelPrinter'
+	#category : #'Pillar-Tests-ExporterText'
 }
 
 { #category : #'tests-templatefiles' }

--- a/src/Pillar-Tests-PetitPillar/PRPillarParserTest.class.st
+++ b/src/Pillar-Tests-PetitPillar/PRPillarParserTest.class.st
@@ -745,14 +745,16 @@ bar')
 
 { #category : #'tests - Reference' }
 PRPillarParserTest >> testReference [
-	super testReference.
+	super testReference. "'*foo>@bar*'"
 	self
 		assert: result
 		equals:
 			(PRInternalLink new
 				add: (PRText content: 'foo');
 				anchor: 'bar';
-				yourself)
+				yourself).
+	self assertStart: 1 stop: 10.
+	self assertStart: 2 stop: 4 ofNode: result children first.
 ]
 
 { #category : #'tests - Reference' }

--- a/src/Pillar-Tests-PetitPillar/PRPillarParserTest.class.st
+++ b/src/Pillar-Tests-PetitPillar/PRPillarParserTest.class.st
@@ -335,7 +335,8 @@ PRPillarParserTest >> testDefinitionList [
 { #category : #'tests - Paragraph' }
 PRPillarParserTest >> testEmptyParagraph [
 	super testEmptyParagraph.
-	self assert: result equals: PREmptyParagraph new
+	self assert: result equals: PREmptyParagraph new.
+	self assertStart: 1 stop: 1
 ]
 
 { #category : #'tests - Reference' }

--- a/src/Pillar-Tests-PetitPillar/PRPillarParserTest.class.st
+++ b/src/Pillar-Tests-PetitPillar/PRPillarParserTest.class.st
@@ -178,7 +178,9 @@ PRPillarParserTest >> testAnnotationParameters [
 		(PRParameter 
 			keyNode: (PRParameterKey named: #timo) 
 			valueNode: (PRParameterValue value: 'leon')) }.
-	self assert: result equals:  expected
+	self assert: result equals:  expected.
+	self assert: result start equals: 2.
+	self assert: result stop equals: 18.
 ]
 
 { #category : #'tests - Annotation' }


### PR DESCRIPTION
Fix AST node start and stop values:
 - figureAlias
 - linkAlias
 - text

Add `Core` and `Exporter` baselines as an initial work on removing circular dependencies among packages. 