### PR TITLE
359-Use-newline-parser-from-PetitParser

### DIFF
--- a/src/Pillar-PetitPillar/PRPillarGrammar.class.st
+++ b/src/Pillar-PetitPillar/PRPillarGrammar.class.st
@@ -6,7 +6,6 @@ Class {
 	#superclass : #PP2CompositeNode,
 	#instVars : [
 		'document',
-		'newline',
 		'lineEnd',
 		'elementsAtLineBeginning',
 		'paragraph',
@@ -126,7 +125,7 @@ Class {
 		'EndMarkups',
 		'Markups'
 	],
-	#category : 'Pillar-PetitPillar'
+	#category : #'Pillar-PetitPillar'
 }
 
 { #category : #accessing }
@@ -269,7 +268,7 @@ PRPillarGrammar >> anchor [
 PRPillarGrammar >> annotatedParagraph [
 	^	epsilonToken , 
 		(Markups at: PRAnnotatedParagraph) asPParser , 
-		($  asPParser / newline) negate star flatten , 
+		($  asPParser / #newline asPParser) negate star flatten , 
 		($  asPParser , oneLineContent) optional ,
 		epsilonToken 
 ]
@@ -350,7 +349,7 @@ PRPillarGrammar >> dataListItem [
 	^	epsilonToken , 
 		dataMarkup and , 
 		dataBasicListItem optional , 
-		((commentedLine , newline) ==> [ :array | array first ]) star , 
+		((commentedLine , #newline asPParser) ==> [ :array | array first ]) star , 
 		dataSubListItem optional , 
 		epsilonToken
 ]
@@ -362,7 +361,7 @@ PRPillarGrammar >> dataMarkup [
 
 { #category : #'grammar - List' }
 PRPillarGrammar >> dataSubListItem [
-	^ ((dataMarkup , subList) / (commentedLine , newline) flatten) plus
+	^ ((dataMarkup , subList) / (commentedLine , #newline asPParser) flatten) plus
 ]
 
 { #category : #'grammar - List' }
@@ -391,9 +390,7 @@ PRPillarGrammar >> elementsAtLineBeginning [
 
 { #category : #'grammar - Paragraph' }
 PRPillarGrammar >> emptyParagraph [
-	^ epsilonToken , 
-		newline , 
-		epsilonToken 
+	^ epsilonToken , #newline asPParser , epsilonToken
 ]
 
 { #category : #'grammar - Helper' }
@@ -485,12 +482,12 @@ PRPillarGrammar >> italicMarkup [
 
 { #category : #'grammar - Text' }
 PRPillarGrammar >> lineBreak [
-	^ newline , elementsAtLineBeginning not
+	^ #newline asPParser , elementsAtLineBeginning not
 ]
 
 { #category : #'grammar - Document' }
 PRPillarGrammar >> lineEnd [
-	^ newline / #eoi asPParser
+	^ #newline asPParser / #eoi asPParser
 ]
 
 { #category : #'grammar - Reference' }
@@ -546,7 +543,7 @@ PRPillarGrammar >> monospaceMarkup [
 
 { #category : #'grammar - Document' }
 PRPillarGrammar >> newline [
-	^ String crlf asPParser / String lf asPParser / String cr asPParser
+	^ #newline asPParser
 ]
 
 { #category : #'grammar - Document' }
@@ -573,7 +570,7 @@ PRPillarGrammar >> orderedListItem [
 	^	epsilonToken , 
 		orderedMarkup and , 
 		orderedBasicListItem optional , 
-		((commentedLine , newline) ==> [ :array | array first ]) star , 
+		((commentedLine , #newline asPParser) ==> [ :array | array first ]) star , 
 		orderedSubListItem optional ,
 		epsilonToken
 ]
@@ -585,7 +582,7 @@ PRPillarGrammar >> orderedMarkup [
 
 { #category : #'grammar - List' }
 PRPillarGrammar >> orderedSubListItem [
-	^ ((orderedMarkup , subList) / (commentedLine , newline) flatten) plus
+	^ ((orderedMarkup , subList) / (commentedLine , #newline asPParser) flatten) plus
 ]
 
 { #category : #'grammar - Document' }
@@ -618,7 +615,7 @@ PRPillarGrammar >> parameterKeyUntilEndLink [
 
 { #category : #'grammar - Parameter' }
 PRPillarGrammar >> parameterKeyUntilNewline [
-	^ self parameterKeyUntilParser: newline
+	^ self parameterKeyUntilParser: #newline asPParser
 ]
 
 { #category : #'grammar - Parameter' }
@@ -683,7 +680,7 @@ PRPillarGrammar >> parameterValueUntilEndLink [
 
 { #category : #'grammar - Parameter' }
 PRPillarGrammar >> parameterValueUntilNewline [
-	^ self parameterValueUntilParser: newline
+	^ self parameterValueUntilParser: #newline asPParser
 ]
 
 { #category : #'grammar - Parameter' }
@@ -784,13 +781,13 @@ PRPillarGrammar >> referenceLink [
 
 { #category : #'grammar - Reference' }
 PRPillarGrammar >> referenceUntil: aParser [
-	^ (escapedCharacter / (aParser / parameterMarkup / newline) negate) plus
+	^ (escapedCharacter / (aParser / parameterMarkup / #newline asPParser) negate) plus
 ]
 
 { #category : #'grammar - Script' }
 PRPillarGrammar >> script [
 	| endParser |
-	endParser := newline asPParser , (EndMarkups at: PRCodeblock) asPParser , space star , lineEnd.
+	endParser := #newline asPParser , (EndMarkups at: PRCodeblock) asPParser , space star , lineEnd.
 	^	epsilonToken, 
 		(Markups at: PRCodeblock) asPParser , 
 		scriptParameters , 
@@ -801,7 +798,7 @@ PRPillarGrammar >> script [
 
 { #category : #'grammar - Script' }
 PRPillarGrammar >> scriptParameters [
-	^ parametersUntilNewline , newline ==> [ :array | array first ]
+	^ parametersUntilNewline , #newline asPParser ==> [ :array | array first ]
 ]
 
 { #category : #'from markdown' }
@@ -922,7 +919,7 @@ PRPillarGrammar >> termListItem [
 	^	epsilonToken , 
 		termMarkup and , 
 		termBasicListItem optional , 
-		((commentedLine , newline) ==> [ :array | array first ]) star , 
+		((commentedLine , #newline asPParser) ==> [ :array | array first ]) star , 
 		termSubListItem optional , 
 		epsilonToken 
 ]
@@ -934,14 +931,14 @@ PRPillarGrammar >> termMarkup [
 
 { #category : #'grammar - List' }
 PRPillarGrammar >> termSubListItem [
-	^ ((termMarkup , subList) / (commentedLine , newline) flatten) plus
+	^ ((termMarkup , subList) / (commentedLine , #newline asPParser) flatten) plus
 ]
 
 { #category : #'grammar - Text' }
 PRPillarGrammar >> text [
 	"Everything that is a pure text and nothing else (not a format, not a link, ...)"
 	^  epsilonToken, 
-		(escapedCharacter / ((newline , elementsAtLineBeginning) / otherContent / lineEnd) negate) plus, 
+		(escapedCharacter / ((#newline asPParser , elementsAtLineBeginning) / otherContent / lineEnd) negate) plus, 
 		epsilonToken
 ]
 
@@ -974,7 +971,7 @@ PRPillarGrammar >> unorderedListItem [
 	^	epsilonToken , 
 		unorderedMarkup and , 
 		unorderedBasicListItem optional , 
-		((commentedLine , newline) ==> [ :array | array first ]) star , 
+		((commentedLine , #newline asPParser) ==> [ :array | array first ]) star , 
 		unorderedSubListItem optional ,
 		epsilonToken
 ]
@@ -986,5 +983,5 @@ PRPillarGrammar >> unorderedMarkup [
 
 { #category : #'grammar - List' }
 PRPillarGrammar >> unorderedSubListItem [
-	^ ((unorderedMarkup , subList) / (commentedLine , newline) flatten) plus
+	^ ((unorderedMarkup , subList) / (commentedLine , #newline asPParser) flatten) plus
 ]

--- a/src/Pillar-PetitPillar/PRPillarGrammar.class.st
+++ b/src/Pillar-PetitPillar/PRPillarGrammar.class.st
@@ -542,11 +542,6 @@ PRPillarGrammar >> monospaceMarkup [
 ]
 
 { #category : #'grammar - Document' }
-PRPillarGrammar >> newline [
-	^ #newline asPParser
-]
-
-{ #category : #'grammar - Document' }
 PRPillarGrammar >> oneLineContent [
 	^ (otherContent / text) plus
 ]

--- a/src/Pillar-PetitPillarOld/PRPillarGrammarOld.class.st
+++ b/src/Pillar-PetitPillarOld/PRPillarGrammarOld.class.st
@@ -6,7 +6,6 @@ Class {
 	#superclass : #PPCompositeParser,
 	#instVars : [
 		'document',
-		'newline',
 		'lineEnd',
 		'elementsAtLineBeginning',
 		'paragraph',
@@ -125,7 +124,7 @@ Class {
 		'EndMarkups',
 		'Markups'
 	],
-	#category : 'Pillar-PetitPillarOld'
+	#category : #'Pillar-PetitPillarOld'
 }
 
 { #category : #accessing }
@@ -266,7 +265,7 @@ PRPillarGrammarOld >> anchor [
 
 { #category : #'grammar - Paragraph' }
 PRPillarGrammarOld >> annotatedParagraph [
-	^ (Markups at: PRAnnotatedParagraph) asParser , ($  asParser / newline) negate star flatten , ($  asParser , oneLineContent) optional
+	^ (Markups at: PRAnnotatedParagraph) asParser , ($  asParser / #newline asParser) negate star flatten , ($  asParser , oneLineContent) optional
 ]
 
 { #category : #'grammar - Annotation' }
@@ -330,7 +329,7 @@ PRPillarGrammarOld >> dataBasicListItem [
 { #category : #'grammar - List' }
 PRPillarGrammarOld >> dataListItem [
 	self flag: #todo.	"This and the overriden method of the parser are REALLY bad. We parse several times the same input, this is bad."
-	^ dataMarkup and , dataBasicListItem optional , ((commentedLine , newline) ==> [ :array | array first ]) star , dataSubListItem optional
+	^ dataMarkup and , dataBasicListItem optional , ((commentedLine , #newline asParser) ==> [ :array | array first ]) star , dataSubListItem optional
 ]
 
 { #category : #'grammar - List' }
@@ -340,7 +339,7 @@ PRPillarGrammarOld >> dataMarkup [
 
 { #category : #'grammar - List' }
 PRPillarGrammarOld >> dataSubListItem [
-	^ ((dataMarkup , subList) / (commentedLine , newline) flatten) plus
+	^ ((dataMarkup , subList) / (commentedLine , #newline asParser) flatten) plus
 ]
 
 { #category : #'grammar - List' }
@@ -367,7 +366,7 @@ PRPillarGrammarOld >> elementsAtLineBeginning [
 
 { #category : #'grammar - Paragraph' }
 PRPillarGrammarOld >> emptyParagraph [
-	^ newline
+	^ #newline asParser
 ]
 
 { #category : #'grammar - Document' }
@@ -435,12 +434,12 @@ PRPillarGrammarOld >> italicMarkup [
 
 { #category : #'grammar - Text' }
 PRPillarGrammarOld >> lineBreak [
-	^ newline , elementsAtLineBeginning not
+	^ #newline asParser , elementsAtLineBeginning not
 ]
 
 { #category : #'grammar - Document' }
 PRPillarGrammarOld >> lineEnd [
-	^ newline / #eof asParser
+	^ #newline asParser / #eof asParser
 ]
 
 { #category : #'grammar - Reference' }
@@ -486,7 +485,7 @@ PRPillarGrammarOld >> monospaceMarkup [
 
 { #category : #'grammar - Document' }
 PRPillarGrammarOld >> newline [
-	^ String crlf asParser / String lf asParser / String cr asParser
+	^ #newline asParser
 ]
 
 { #category : #'grammar - Document' }
@@ -508,7 +507,7 @@ PRPillarGrammarOld >> orderedList [
 { #category : #'grammar - List' }
 PRPillarGrammarOld >> orderedListItem [
 	self flag: #todo.	"This and the overriden method of the parser are REALLY bad. We parse several times the same input, this is bad."
-	^ orderedMarkup and , orderedBasicListItem optional , ((commentedLine , newline) ==> [ :array | array first ]) star , orderedSubListItem optional
+	^ orderedMarkup and , orderedBasicListItem optional , ((commentedLine , #newline asParser) ==> [ :array | array first ]) star , orderedSubListItem optional
 ]
 
 { #category : #'grammar - List' }
@@ -518,7 +517,7 @@ PRPillarGrammarOld >> orderedMarkup [
 
 { #category : #'grammar - List' }
 PRPillarGrammarOld >> orderedSubListItem [
-	^ ((orderedMarkup , subList) / (commentedLine , newline) flatten) plus
+	^ ((orderedMarkup , subList) / (commentedLine , #newline asParser) flatten) plus
 ]
 
 { #category : #'grammar - Document' }
@@ -548,7 +547,7 @@ PRPillarGrammarOld >> parameterKeyUntilEndLink [
 
 { #category : #'grammar - Parameter' }
 PRPillarGrammarOld >> parameterKeyUntilNewline [
-	^ self parameterKeyUntilParser: newline
+	^ self parameterKeyUntilParser: #newline asParser
 ]
 
 { #category : #'grammar - Parameter' }
@@ -608,7 +607,7 @@ PRPillarGrammarOld >> parameterValueUntilEndLink [
 
 { #category : #'grammar - Parameter' }
 PRPillarGrammarOld >> parameterValueUntilNewline [
-	^ self parameterValueUntilParser: newline
+	^ self parameterValueUntilParser: #newline asParser
 ]
 
 { #category : #'grammar - Parameter' }
@@ -706,19 +705,19 @@ PRPillarGrammarOld >> referenceLink [
 
 { #category : #'grammar - Reference' }
 PRPillarGrammarOld >> referenceUntil: aParser [
-	^ (escapedCharacter / (aParser / parameterMarkup / newline) negate) plus
+	^ (escapedCharacter / (aParser / parameterMarkup / #newline asParser) negate) plus
 ]
 
 { #category : #'grammar - Script' }
 PRPillarGrammarOld >> script [
 	| endParser |
-	endParser := newline asParser , (EndMarkups at: PRCodeblock) asParser , space star , lineEnd.
+	endParser := #newline asParser , (EndMarkups at: PRCodeblock) asParser , space star , lineEnd.
 	^ (Markups at: PRCodeblock) asParser , scriptParameters , endParser negate plus flatten , endParser
 ]
 
 { #category : #'grammar - Script' }
 PRPillarGrammarOld >> scriptParameters [
-	^ parametersUntilNewline , newline ==> [ :array | array first ]
+	^ parametersUntilNewline , #newline asParser ==> [ :array | array first ]
 ]
 
 { #category : #'from markdown' }
@@ -836,7 +835,7 @@ PRPillarGrammarOld >> termBasicListItem [
 { #category : #'grammar - List' }
 PRPillarGrammarOld >> termListItem [
 	self flag: #todo.	"This and the overriden method of the parser are REALLY bad. We parse several times the same input, this is bad."
-	^ termMarkup and , termBasicListItem optional , ((commentedLine , newline) ==> [ :array | array first ]) star , termSubListItem optional
+	^ termMarkup and , termBasicListItem optional , ((commentedLine , #newline asParser) ==> [ :array | array first ]) star , termSubListItem optional
 ]
 
 { #category : #'grammar - List' }
@@ -846,13 +845,13 @@ PRPillarGrammarOld >> termMarkup [
 
 { #category : #'grammar - List' }
 PRPillarGrammarOld >> termSubListItem [
-	^ ((termMarkup , subList) / (commentedLine , newline) flatten) plus
+	^ ((termMarkup , subList) / (commentedLine , #newline asParser) flatten) plus
 ]
 
 { #category : #'grammar - Text' }
 PRPillarGrammarOld >> text [
 	"Everything that is a pure text and nothing else (not a format, not a link, ...)"
-	^  (escapedCharacter / ((newline , elementsAtLineBeginning) / otherContent / lineEnd) negate) plus
+	^  (escapedCharacter / ((#newline asParser , elementsAtLineBeginning) / otherContent / lineEnd) negate) plus
 ]
 
 { #category : #'grammar - Format' }
@@ -879,7 +878,7 @@ PRPillarGrammarOld >> unorderedList [
 { #category : #'grammar - List' }
 PRPillarGrammarOld >> unorderedListItem [
 	self flag: #todo.	"This and the overriden method of the parser are REALLY bad. We parse several times the same input, this is bad."
-	^ unorderedMarkup and , unorderedBasicListItem optional , ((commentedLine , newline) ==> [ :array | array first ]) star , unorderedSubListItem optional
+	^ unorderedMarkup and , unorderedBasicListItem optional , ((commentedLine , #newline asParser) ==> [ :array | array first ]) star , unorderedSubListItem optional
 ]
 
 { #category : #'grammar - List' }
@@ -889,5 +888,5 @@ PRPillarGrammarOld >> unorderedMarkup [
 
 { #category : #'grammar - List' }
 PRPillarGrammarOld >> unorderedSubListItem [
-	^ ((unorderedMarkup , subList) / (commentedLine , newline) flatten) plus
+	^ ((unorderedMarkup , subList) / (commentedLine , #newline asParser) flatten) plus
 ]

--- a/src/Pillar-PetitPillarOld/PRPillarGrammarOld.class.st
+++ b/src/Pillar-PetitPillarOld/PRPillarGrammarOld.class.st
@@ -484,11 +484,6 @@ PRPillarGrammarOld >> monospaceMarkup [
 ]
 
 { #category : #'grammar - Document' }
-PRPillarGrammarOld >> newline [
-	^ #newline asParser
-]
-
-{ #category : #'grammar - Document' }
 PRPillarGrammarOld >> oneLineContent [
 	^ (otherContent / text) plus
 ]

--- a/src/Pillar-Tests-PetitPillar/PRPillarGrammarTest.class.st
+++ b/src/Pillar-Tests-PetitPillar/PRPillarGrammarTest.class.st
@@ -322,26 +322,6 @@ PRPillarGrammarTest >> testMonospaceFormatWithEscaped [
 	self parse: '==\=\===' rule: #format
 ]
 
-{ #category : #'tests - Document' }
-PRPillarGrammarTest >> testNewline [
-	self parse: Smalltalk os lineEnding rule: #newline
-]
-
-{ #category : #'tests - Document' }
-PRPillarGrammarTest >> testNewlineCR [
-	self parse: String cr rule: #newline
-]
-
-{ #category : #'tests - Document' }
-PRPillarGrammarTest >> testNewlineCRLF [
-	self parse: String crlf rule: #newline
-]
-
-{ #category : #'tests - Document' }
-PRPillarGrammarTest >> testNewlineLF [
-	self parse: String lf rule: #newline
-]
-
 { #category : #'tests - List' }
 PRPillarGrammarTest >> testOrderedList [
 	self parse: '#Foo' rule: #orderedList

--- a/src/Pillar-Tests-PetitPillarOld/PRPillarGrammarOldTest.class.st
+++ b/src/Pillar-Tests-PetitPillarOld/PRPillarGrammarOldTest.class.st
@@ -297,26 +297,6 @@ PRPillarGrammarOldTest >> testMonospaceFormatWithEscaped [
 	self parse: '==\=\===' rule: #format
 ]
 
-{ #category : #'tests - Document' }
-PRPillarGrammarOldTest >> testNewline [
-	self parse: Smalltalk os lineEnding rule: #newline
-]
-
-{ #category : #'tests - Document' }
-PRPillarGrammarOldTest >> testNewlineCR [
-	self parse: String cr rule: #newline
-]
-
-{ #category : #'tests - Document' }
-PRPillarGrammarOldTest >> testNewlineCRLF [
-	self parse: String crlf rule: #newline
-]
-
-{ #category : #'tests - Document' }
-PRPillarGrammarOldTest >> testNewlineLF [
-	self parse: String lf rule: #newline
-]
-
 { #category : #'tests - List' }
 PRPillarGrammarOldTest >> testOrderedList [
 	self parse: '#Foo' rule: #orderedList


### PR DESCRIPTION
Use the #newline parser from PetitParser instead of a newline parser created in Pillar.

Fixes #359