### PR TITLE
373-Markdown-exporter-does-not-write-a-newline-before-a-codeblock---

### DIFF
--- a/src/Pillar-ExporterMarkdown/PRMarkdownWriter.class.st
+++ b/src/Pillar-ExporterMarkdown/PRMarkdownWriter.class.st
@@ -257,20 +257,23 @@ PRMarkdownWriter >> writeInternalLink: anInternalLink withRef: href [
 		destination: href
 ]
 
-{ #category : #'visiting-document' }
+{ #category : #writing }
 PRMarkdownWriter >> writeScript: aScript [
 	"http://spec.commonmark.org/0.28/#fenced-code-blocks"
 
 	"I am not using indented code blocks (http://spec.commonmark.org/0.28/#indented-code-blocks), because they have no info strings (http://spec.commonmark.org/0.28/#info-string)"
 
 	| language |
-	canvas raw: '```'.
+	canvas
+		newLine;
+		raw: '```'.
 	language := self languageForScript: aScript.
 	language isSyntaxHighlightingPossible
 		ifTrue: [ canvas raw: language originalName ].
-	canvas newLine.
-	canvas raw: aScript text.
-	canvas newLine.
-	canvas raw: '```'.
-	canvas newLine
+	canvas
+		newLine;
+		raw: aScript text;
+		newLine;
+		raw: '```';
+		newLine
 ]

--- a/src/Pillar-Tests-ExporterMarkdown/PRGithubMarkdownWriterTest.class.st
+++ b/src/Pillar-Tests-ExporterMarkdown/PRGithubMarkdownWriterTest.class.st
@@ -11,12 +11,12 @@ PRGithubMarkdownWriterTest >> actualClass [
 
 { #category : #requirements }
 PRGithubMarkdownWriterTest >> scriptWithCaptionBegin [
-	^ '```'
+	^ self configuration newLine , '```'
 ]
 
 { #category : #requirements }
 PRGithubMarkdownWriterTest >> scriptWithoutCaptionBegin [
-	^ String cr, '```'
+	^ self configuration newLine , '```'
 ]
 
 { #category : #requirements }

--- a/src/Pillar-Tests-ExporterMarkdown/PRGithubMarkdownWriterTest.class.st
+++ b/src/Pillar-Tests-ExporterMarkdown/PRGithubMarkdownWriterTest.class.st
@@ -16,7 +16,7 @@ PRGithubMarkdownWriterTest >> scriptWithCaptionBegin [
 
 { #category : #requirements }
 PRGithubMarkdownWriterTest >> scriptWithoutCaptionBegin [
-	^ '```'
+	^ String cr, '```'
 ]
 
 { #category : #requirements }

--- a/src/Pillar-Tests-ExporterMarkdown/PRMarkdownWriterTest.class.st
+++ b/src/Pillar-Tests-ExporterMarkdown/PRMarkdownWriterTest.class.st
@@ -201,20 +201,21 @@ PRMarkdownWriterTest >> resultWithoutRefWithAnchorWithSeparateOutputFiles [
 
 { #category : #requirements }
 PRMarkdownWriterTest >> scriptAnchorForMyScript [
-	
-	^ '```
+	^ self configuration newLine
+		,
+			'```
 myscript
 ```'
 ]
 
 { #category : #requirements }
 PRMarkdownWriterTest >> scriptWithCaptionBegin [
-	^ '```'
+	^ self configuration newLine , '```'
 ]
 
 { #category : #requirements }
 PRMarkdownWriterTest >> scriptWithoutCaptionBegin [
-	^ '```'
+	^ self configuration newLine , '```'
 ]
 
 { #category : #requirements }


### PR DESCRIPTION
PRMarkdownWriter emits newline before ```.  And tests.