### PR TITLE
389-PRVisitor-and-Model-classes-should-not-return-self

### DIFF
--- a/src/Pillar-BookTester/PRLoaderAnnotation.class.st
+++ b/src/Pillar-BookTester/PRLoaderAnnotation.class.st
@@ -18,7 +18,7 @@ Note:
 Class {
 	#name : #PRLoaderAnnotation,
 	#superclass : #PRAbstractAnnotation,
-	#category : 'Pillar-BookTester-Annotations'
+	#category : #'Pillar-BookTester-Annotations'
 }
 
 { #category : #accessing }
@@ -36,7 +36,7 @@ PRLoaderAnnotation class >> tag [
 { #category : #visiting }
 PRLoaderAnnotation >> accept: aVisitor [
 
-	aVisitor visitLoaderAnnotation: self
+	^ aVisitor visitLoaderAnnotation: self
 ]
 
 { #category : #visiting }

--- a/src/Pillar-BookTester/PRRunAnnotation.class.st
+++ b/src/Pillar-BookTester/PRRunAnnotation.class.st
@@ -16,7 +16,7 @@ Note:
 Class {
 	#name : #PRRunAnnotation,
 	#superclass : #PRAbstractAnnotation,
-	#category : 'Pillar-BookTester-Annotations'
+	#category : #'Pillar-BookTester-Annotations'
 }
 
 { #category : #accessing }
@@ -40,5 +40,5 @@ PRRunAnnotation class >> tag [
 { #category : #visiting }
 PRRunAnnotation >> accept: aVisitor [
 
-	aVisitor visitRunAnnotation: self
+	^ aVisitor visitRunAnnotation: self
 ]

--- a/src/Pillar-BookTester/PRScreenshotAnnotation.class.st
+++ b/src/Pillar-BookTester/PRScreenshotAnnotation.class.st
@@ -21,7 +21,7 @@ Note:
 Class {
 	#name : #PRScreenshotAnnotation,
 	#superclass : #PRAbstractAnnotation,
-	#category : 'Pillar-BookTester-Annotations'
+	#category : #'Pillar-BookTester-Annotations'
 }
 
 { #category : #accessing }
@@ -39,7 +39,7 @@ PRScreenshotAnnotation class >> tag [
 { #category : #visiting }
 PRScreenshotAnnotation >> accept: aVisitor [
 
-	aVisitor visitScreenshotAnnotation: self
+	^ aVisitor visitScreenshotAnnotation: self
 ]
 
 { #category : #visiting }

--- a/src/Pillar-BookTester/PRShowClassAnnotation.class.st
+++ b/src/Pillar-BookTester/PRShowClassAnnotation.class.st
@@ -16,7 +16,7 @@ Note:
 Class {
 	#name : #PRShowClassAnnotation,
 	#superclass : #PRAbstractAnnotation,
-	#category : 'Pillar-BookTester-Annotations'
+	#category : #'Pillar-BookTester-Annotations'
 }
 
 { #category : #accessing }
@@ -40,7 +40,7 @@ PRShowClassAnnotation class >> tag [
 { #category : #visiting }
 PRShowClassAnnotation >> accept: aVisitor [
 
-	aVisitor visitShowClassAnnotation: self
+	^ aVisitor visitShowClassAnnotation: self
 ]
 
 { #category : #accessing }

--- a/src/Pillar-BookTester/PRShowMethodAnnotation.class.st
+++ b/src/Pillar-BookTester/PRShowMethodAnnotation.class.st
@@ -17,7 +17,7 @@ Note:
 Class {
 	#name : #PRShowMethodAnnotation,
 	#superclass : #PRAbstractAnnotation,
-	#category : 'Pillar-BookTester-Annotations'
+	#category : #'Pillar-BookTester-Annotations'
 }
 
 { #category : #accessing }
@@ -41,7 +41,7 @@ PRShowMethodAnnotation class >> tag [
 { #category : #visiting }
 PRShowMethodAnnotation >> accept: aVisitor [
 
-	aVisitor visitShowMethodAnnotation: self
+	^ aVisitor visitShowMethodAnnotation: self
 ]
 
 { #category : #accessing }

--- a/src/Pillar-BookTester/PRVisitor.extension.st
+++ b/src/Pillar-BookTester/PRVisitor.extension.st
@@ -2,25 +2,25 @@ Extension { #name : #PRVisitor }
 
 { #category : #'*Pillar-BookTester' }
 PRVisitor >> visitLoaderAnnotation: aLoaderAnnotation [ 
-	self visitAnnotation: aLoaderAnnotation
+	^ self visitAnnotation: aLoaderAnnotation
 ]
 
 { #category : #'*Pillar-BookTester' }
 PRVisitor >> visitRunAnnotation: aRunAnnotation [ 
-	self visitAnnotation: aRunAnnotation
+	^ self visitAnnotation: aRunAnnotation
 ]
 
 { #category : #'*Pillar-BookTester' }
 PRVisitor >> visitScreenshotAnnotation: aScreenshotAnnotation [ 
-	self visitAnnotation: aScreenshotAnnotation
+	^ self visitAnnotation: aScreenshotAnnotation
 ]
 
 { #category : #'*Pillar-BookTester' }
 PRVisitor >> visitShowClassAnnotation: aShowClassAnnotation [ 
-	self visitAnnotation: aShowClassAnnotation
+	^ self visitAnnotation: aShowClassAnnotation
 ]
 
 { #category : #'*Pillar-BookTester' }
 PRVisitor >> visitShowMethodAnnotation: aShowMethodAnnotation [ 
-	self visitAnnotation: aShowMethodAnnotation
+	^ self visitAnnotation: aShowMethodAnnotation
 ]

--- a/src/Pillar-Core/PRAbstractAnnotation.class.st
+++ b/src/Pillar-Core/PRAbstractAnnotation.class.st
@@ -155,7 +155,7 @@ PRAbstractAnnotation >> = anObject [
 { #category : #visiting }
 PRAbstractAnnotation >> accept: aVisitor [
 
-	aVisitor visitAnnotation: self
+	^ aVisitor visitAnnotation: self
 ]
 
 { #category : #rendering }

--- a/src/Pillar-Core/PRAnchor.class.st
+++ b/src/Pillar-Core/PRAnchor.class.st
@@ -28,7 +28,7 @@ PRAnchor >> = anObject [
 
 { #category : #visiting }
 PRAnchor >> accept: aVisitor [
-	aVisitor visitAnchor: self
+	^ aVisitor visitAnchor: self
 ]
 
 { #category : #comparing }

--- a/src/Pillar-Core/PRBeginEnvironmentAnnotation.class.st
+++ b/src/Pillar-Core/PRBeginEnvironmentAnnotation.class.st
@@ -29,5 +29,5 @@ PRBeginEnvironmentAnnotation class >> tag [
 
 { #category : #visiting }
 PRBeginEnvironmentAnnotation >> accept: aVisitor [
-	aVisitor visitBeginEnvironmentAnnotation: self
+	^ aVisitor visitBeginEnvironmentAnnotation: self
 ]

--- a/src/Pillar-Core/PRBoldFormat.class.st
+++ b/src/Pillar-Core/PRBoldFormat.class.st
@@ -14,5 +14,5 @@ PRBoldFormat class >> isAbstract [
 
 { #category : #visiting }
 PRBoldFormat >> accept: aVisitor [
-	aVisitor visitBoldFormat: self
+	^ aVisitor visitBoldFormat: self
 ]

--- a/src/Pillar-Core/PRCodeblock.class.st
+++ b/src/Pillar-Core/PRCodeblock.class.st
@@ -55,7 +55,7 @@ PRCodeblock >> = anObject [
 
 { #category : #visiting }
 PRCodeblock >> accept: aVisitor [
-	aVisitor visitCodeblock: self
+	^ aVisitor visitCodeblock: self
 ]
 
 { #category : #'accessing-delegated' }

--- a/src/Pillar-Core/PRDocument.class.st
+++ b/src/Pillar-Core/PRDocument.class.st
@@ -14,7 +14,7 @@ PRDocument class >> isAbstract [
 
 { #category : #visiting }
 PRDocument >> accept: aVisitor [
-	aVisitor visitDocument: self
+	^ aVisitor visitDocument: self
 ]
 
 { #category : #'common-properties' }

--- a/src/Pillar-Core/PRDocumentGroup.class.st
+++ b/src/Pillar-Core/PRDocumentGroup.class.st
@@ -39,7 +39,7 @@ PRDocumentGroup >> = anObject [
 { #category : #visiting }
 PRDocumentGroup >> accept: aVisitor [
 	<ignoreForCoverage "This method is ignored for test coverage because it is overriden in all subclasses and these subclasses don't need to do a super-send.">
-	aVisitor visitDocumentGroup: self
+	^ aVisitor visitDocumentGroup: self
 ]
 
 { #category : #adding }

--- a/src/Pillar-Core/PRDocumentItem.class.st
+++ b/src/Pillar-Core/PRDocumentItem.class.st
@@ -36,7 +36,7 @@ PRDocumentItem >> = anObject [
 { #category : #visiting }
 PRDocumentItem >> accept: aVisitor [
 	<ignoreForCoverage "This method is ignored for test coverage because it is overriden in all subclasses and these subclasses don't need to do a super-send.">
-	aVisitor visitDocumentItem: self
+	^ aVisitor visitDocumentItem: self
 ]
 
 { #category : #accessing }

--- a/src/Pillar-Core/PREmptyParagraph.class.st
+++ b/src/Pillar-Core/PREmptyParagraph.class.st
@@ -9,5 +9,5 @@ Class {
 
 { #category : #visiting }
 PREmptyParagraph >> accept: aVisitor [
-	aVisitor visitEmptyParagraph: self
+	^ aVisitor visitEmptyParagraph: self
 ]

--- a/src/Pillar-Core/PREndEnvironmentAnnotation.class.st
+++ b/src/Pillar-Core/PREndEnvironmentAnnotation.class.st
@@ -29,5 +29,5 @@ PREndEnvironmentAnnotation class >> tag [
 
 { #category : #visiting }
 PREndEnvironmentAnnotation >> accept: aVisitor [
-	aVisitor visitEndEnvironmentAnnotation: self
+	^ aVisitor visitEndEnvironmentAnnotation: self
 ]

--- a/src/Pillar-Core/PREnvironment.class.st
+++ b/src/Pillar-Core/PREnvironment.class.st
@@ -37,7 +37,7 @@ PREnvironment class >> named: aString [
 
 { #category : #visiting }
 PREnvironment >> accept: aVisitor [
-	aVisitor visitEnvironment: self
+	^ aVisitor visitEnvironment: self
 ]
 
 { #category : #accessing }

--- a/src/Pillar-Core/PRExternalLink.class.st
+++ b/src/Pillar-Core/PRExternalLink.class.st
@@ -24,7 +24,7 @@ PRExternalLink class >> priority [
 
 { #category : #visiting }
 PRExternalLink >> accept: aVisitor [
-	aVisitor visitExternalLink: self
+	^ aVisitor visitExternalLink: self
 ]
 
 { #category : #testing }

--- a/src/Pillar-Core/PRFigure.class.st
+++ b/src/Pillar-Core/PRFigure.class.st
@@ -32,7 +32,7 @@ PRFigure class >> pictureExtensions [
 
 { #category : #visiting }
 PRFigure >> accept: aVisitor [
-	aVisitor visitFigure: self
+	^ aVisitor visitFigure: self
 ]
 
 { #category : #testing }

--- a/src/Pillar-Core/PRFormat.class.st
+++ b/src/Pillar-Core/PRFormat.class.st
@@ -10,5 +10,5 @@ Class {
 { #category : #visiting }
 PRFormat >> accept: aVisitor [
 	<ignoreForCoverage "This method is ignored for test coverage because it is overriden in all subclasses and these subclasses don't need to do a super-send.">
-	aVisitor visitFormat: self
+	^ aVisitor visitFormat: self
 ]

--- a/src/Pillar-Core/PRHeader.class.st
+++ b/src/Pillar-Core/PRHeader.class.st
@@ -30,7 +30,7 @@ PRHeader >> = anObject [
 
 { #category : #visiting }
 PRHeader >> accept: aVisitor [
-	aVisitor visitHeader: self
+	^ aVisitor visitHeader: self
 ]
 
 { #category : #comparing }

--- a/src/Pillar-Core/PRInternalLink.class.st
+++ b/src/Pillar-Core/PRInternalLink.class.st
@@ -49,7 +49,7 @@ PRInternalLink >> = anObject [
 
 { #category : #visiting }
 PRInternalLink >> accept: aVisitor [
-	aVisitor visitInternalLink: self
+	^ aVisitor visitInternalLink: self
 ]
 
 { #category : #accessing }

--- a/src/Pillar-Core/PRItalicFormat.class.st
+++ b/src/Pillar-Core/PRItalicFormat.class.st
@@ -14,5 +14,5 @@ PRItalicFormat class >> isAbstract [
 
 { #category : #visiting }
 PRItalicFormat >> accept: aVisitor [
-	aVisitor visitItalicFormat: self
+	^ aVisitor visitItalicFormat: self
 ]

--- a/src/Pillar-Core/PRLineBreak.class.st
+++ b/src/Pillar-Core/PRLineBreak.class.st
@@ -14,5 +14,5 @@ PRLineBreak class >> isAbstract [
 
 { #category : #visiting }
 PRLineBreak >> accept: aVisitor [
-	aVisitor visitLineBreak: self
+	^ aVisitor visitLineBreak: self
 ]

--- a/src/Pillar-Core/PRLink.class.st
+++ b/src/Pillar-Core/PRLink.class.st
@@ -33,7 +33,7 @@ PRLink class >> priority [
 { #category : #visiting }
 PRLink >> accept: aVisitor [
 	<ignoreForCoverage "This method is ignored for test coverage because it is overriden in all subclasses and these subclasses don't need to do a super-send.">
-	aVisitor visitLink: self
+	^ aVisitor visitLink: self
 ]
 
 { #category : #testing }

--- a/src/Pillar-Core/PRList.class.st
+++ b/src/Pillar-Core/PRList.class.st
@@ -12,5 +12,5 @@ Class {
 { #category : #visiting }
 PRList >> accept: aVisitor [
 	<ignoreForCoverage "This method is ignored for test coverage because it is overriden in all subclasses and these subclasses don't need to do a super-send.">
-	aVisitor visitList: self
+	^ aVisitor visitList: self
 ]

--- a/src/Pillar-Core/PRListItem.class.st
+++ b/src/Pillar-Core/PRListItem.class.st
@@ -17,5 +17,5 @@ PRListItem class >> isAbstract [
 
 { #category : #visiting }
 PRListItem >> accept: aVisitor [
-	aVisitor visitListItem: self
+	^ aVisitor visitListItem: self
 ]

--- a/src/Pillar-Core/PRMailLink.class.st
+++ b/src/Pillar-Core/PRMailLink.class.st
@@ -22,7 +22,7 @@ PRMailLink class >> priority [
 
 { #category : #visiting }
 PRMailLink >> accept: aVisitor [
-	aVisitor visitMailLink: self
+	^ aVisitor visitMailLink: self
 ]
 
 { #category : #'accessing-dynamic' }

--- a/src/Pillar-Core/PRMonospaceFormat.class.st
+++ b/src/Pillar-Core/PRMonospaceFormat.class.st
@@ -14,5 +14,5 @@ PRMonospaceFormat class >> isAbstract [
 
 { #category : #visiting }
 PRMonospaceFormat >> accept: aVisitor [
-	aVisitor visitMonospaceFormat: self
+	^ aVisitor visitMonospaceFormat: self
 ]

--- a/src/Pillar-Core/PROrderedList.class.st
+++ b/src/Pillar-Core/PROrderedList.class.st
@@ -14,5 +14,5 @@ PROrderedList class >> isAbstract [
 
 { #category : #visiting }
 PROrderedList >> accept: aVisitor [
-	aVisitor visitOrderedList: self
+	^ aVisitor visitOrderedList: self
 ]

--- a/src/Pillar-Core/PRParagraph.class.st
+++ b/src/Pillar-Core/PRParagraph.class.st
@@ -16,5 +16,5 @@ PRParagraph class >> isAbstract [
 
 { #category : #visiting }
 PRParagraph >> accept: aVisitor [
-	aVisitor visitParagraph: self
+	^ aVisitor visitParagraph: self
 ]

--- a/src/Pillar-Core/PRPreformatted.class.st
+++ b/src/Pillar-Core/PRPreformatted.class.st
@@ -14,5 +14,5 @@ PRPreformatted class >> isAbstract [
 
 { #category : #visiting }
 PRPreformatted >> accept: aVisitor [
-	aVisitor visitPreformatted: self
+	^ aVisitor visitPreformatted: self
 ]

--- a/src/Pillar-Core/PRReference.class.st
+++ b/src/Pillar-Core/PRReference.class.st
@@ -42,7 +42,7 @@ PRReference >> = anObject [
 { #category : #visiting }
 PRReference >> accept: aVisitor [
 	<ignoreForCoverage "This method is ignored for test coverage because it is overriden in all subclasses and these subclasses don't need to do a super-send.">
-	aVisitor visitReference: self
+	^ aVisitor visitReference: self
 ]
 
 { #category : #'accessing-dynamic' }

--- a/src/Pillar-Core/PRSection.class.st
+++ b/src/Pillar-Core/PRSection.class.st
@@ -14,5 +14,5 @@ PRSection class >> isAbstract [
 
 { #category : #visiting }
 PRSection >> accept: aVisitor [
-	aVisitor visitSection: self
+	^ aVisitor visitSection: self
 ]

--- a/src/Pillar-Core/PRText.class.st
+++ b/src/Pillar-Core/PRText.class.st
@@ -28,7 +28,7 @@ PRText >> = anObject [
 
 { #category : #visiting }
 PRText >> accept: aVisitor [
-	aVisitor visitText: self
+	^ aVisitor visitText: self
 ]
 
 { #category : #comparing }

--- a/src/Pillar-Core/PRVisitor.class.st
+++ b/src/Pillar-Core/PRVisitor.class.st
@@ -9,17 +9,17 @@ Class {
 
 { #category : #visiting }
 PRVisitor >> start: anObject [
-	self visit: anObject
+	^ self visit: anObject
 ]
 
 { #category : #visiting }
 PRVisitor >> visit: anObject [
-	anObject acceptDecorated: self
+	^ anObject acceptDecorated: self
 ]
 
 { #category : #visiting }
 PRVisitor >> visitAll: aCollection [
-	aCollection do: [ :each | self visit: each ]
+	^aCollection collect: [ :each | self visit: each ]
 ]
 
 { #category : #visiting }
@@ -29,34 +29,34 @@ PRVisitor >> visitAll: aCollection separatedBy: aBlock [
 
 { #category : #'visiting-document' }
 PRVisitor >> visitAnchor: anObject [
-	self visitDocumentItem: anObject
+	^ self visitDocumentItem: anObject
 ]
 
 { #category : #'visiting-document' }
 PRVisitor >> visitAnnotatedParagraph: aDocument [
-	self visitParagraph: aDocument
+	^ self visitParagraph: aDocument
 ]
 
 { #category : #'visiting-annotations' }
 PRVisitor >> visitAnnotation: anAnnotation [
 	"Visiting an annotation means that we visit the textual representation of an annotation. Such annotations will be transformed into annotation object. The corresponding visit method will be invoked on such object : visitCitationAnnotation vs visitCitation."
-	self visitDocumentGroup: anAnnotation
+	^ self visitDocumentGroup: anAnnotation
 ]
 
 { #category : #'visiting-annotations' }
 PRVisitor >> visitBeginEnvironmentAnnotation: aBeginEnvironmentAnnotation [
 	"Visiting an annotation means that we visit the textual representation of an annotation. Such annotations will be transformed into annotation object. The corresponding visit method will be invoked on such object : visitBeginEnvironmentAnnotation vs visitBeginEnvironment."
-	self visitAnnotation: aBeginEnvironmentAnnotation
+	^ self visitAnnotation: aBeginEnvironmentAnnotation
 ]
 
 { #category : #'visiting-document' }
 PRVisitor >> visitBoldFormat: anObject [
-	self visitFormat: anObject
+	^ self visitFormat: anObject
 ]
 
 { #category : #'visiting-document' }
 PRVisitor >> visitCodeblock: aCodeBlock [ 
-	self visitText: aCodeBlock
+	^ self visitText: aCodeBlock
 ]
 
 { #category : #'visiting-document' }
@@ -66,22 +66,22 @@ PRVisitor >> visitCommentedLine: aCommentedLine [
 
 { #category : #'visiting-document' }
 PRVisitor >> visitDataItem: anObject [
-	self visitListItem: anObject
+	^ self visitListItem: anObject
 ]
 
 { #category : #'visiting-document' }
 PRVisitor >> visitDefinitionList: anObject [
-	self visitList: anObject
+	^ self visitList: anObject
 ]
 
 { #category : #'visiting-document' }
 PRVisitor >> visitDocument: anObject [
-	self visitDocumentGroup: anObject
+	^ self visitDocumentGroup: anObject
 ]
 
 { #category : #'visiting-document' }
 PRVisitor >> visitDocumentGroup: anObject [
-	self visitAll: anObject children
+	^ self visitAll: anObject children
 ]
 
 { #category : #'visiting-document' }
@@ -92,7 +92,7 @@ PRVisitor >> visitDocumentItem: anObject [
 PRVisitor >> visitEmptyParagraph: anObject [
 	<ignoreForCoverage "This method is ignored for coverage because visiting an empty paragraph is typically very much different from visiting a paragraph.">
 	
-	self visitParagraph: anObject
+	^ self visitParagraph: anObject
 ]
 
 { #category : #'visiting-document' }
@@ -100,83 +100,83 @@ PRVisitor >> visitEnvironment: anObject [
 	"An environment object has been created based on the begin and end annotations.
 	My subclasses may want to introduce a preAction and postAction triggering. By default just visit all children."
 	
-	self visitDocumentGroup: anObject
+	^ self visitDocumentGroup: anObject
 ]
 
 { #category : #'visiting-document' }
 PRVisitor >> visitExternalLink: anObject [
-	self visitLink: anObject
+	^ self visitLink: anObject
 ]
 
 { #category : #'visiting-document' }
 PRVisitor >> visitFigure: anObject [
-	self visitReference: anObject
+	^ self visitReference: anObject
 ]
 
 { #category : #'visiting-document' }
 PRVisitor >> visitFormat: anObject [
-	self visitDocumentGroup: anObject
+	^ self visitDocumentGroup: anObject
 ]
 
 { #category : #'visiting-document' }
 PRVisitor >> visitHeader: anObject [
-	self visitDocumentGroup: anObject
+	^ self visitDocumentGroup: anObject
 ]
 
 { #category : #'visiting-document' }
 PRVisitor >> visitHorizontalRule: anObject [
-	self visitDocumentItem: anObject
+	^ self visitDocumentItem: anObject
 ]
 
 { #category : #'visiting-document' }
 PRVisitor >> visitInternalLink: anObject [
-	self visitLink: anObject
+	^ self visitLink: anObject
 ]
 
 { #category : #'visiting-document' }
 PRVisitor >> visitItalicFormat: anObject [
-	self visitFormat: anObject
+	^ self visitFormat: anObject
 ]
 
 { #category : #'visiting-document' }
 PRVisitor >> visitLineBreak: anObject [
 	<ignoreForCoverage "This method is ignored for coverage because visiting a line break is typically very much different from visiting a standard document item.">
-	self visitDocumentItem: anObject
+	^ self visitDocumentItem: anObject
 ]
 
 { #category : #'visiting-document' }
 PRVisitor >> visitLink: anObject [
-	self visitReference: anObject
+	^ self visitReference: anObject
 ]
 
 { #category : #'visiting-document' }
 PRVisitor >> visitList: anObject [
-	self visitDocumentGroup: anObject
+	^ self visitDocumentGroup: anObject
 ]
 
 { #category : #'visiting-document' }
 PRVisitor >> visitListItem: anObject [
-	self visitDocumentGroup: anObject
+	^ self visitDocumentGroup: anObject
 ]
 
 { #category : #'visiting-document' }
 PRVisitor >> visitMailLink: anObject [
-	self visitExternalLink: anObject
+	^ self visitExternalLink: anObject
 ]
 
 { #category : #'visiting-document' }
 PRVisitor >> visitMonospaceFormat: anObject [
-	self visitFormat: anObject
+	^ self visitFormat: anObject
 ]
 
 { #category : #'visiting-document' }
 PRVisitor >> visitOrderedList: anObject [
-	self visitList: anObject
+	^ self visitList: anObject
 ]
 
 { #category : #'visiting-document' }
 PRVisitor >> visitParagraph: anObject [
-	self visitDocumentGroup: anObject
+	^ self visitDocumentGroup: anObject
 ]
 
 { #category : #'visiting-parameters' }
@@ -201,47 +201,47 @@ PRVisitor >> visitParameters: anObject [
 
 { #category : #'visiting-document' }
 PRVisitor >> visitPreformatted: anObject [
-	self visitDocumentGroup: anObject
+	^ self visitDocumentGroup: anObject
 ]
 
 { #category : #'visiting-document' }
 PRVisitor >> visitRaw: aRaw [
-	self visitText: aRaw
+	^ self visitText: aRaw
 ]
 
 { #category : #'visiting-document' }
 PRVisitor >> visitReference: anObject [
-	self visitDocumentGroup: anObject
+	^ self visitDocumentGroup: anObject
 ]
 
 { #category : #'visiting-document' }
 PRVisitor >> visitSection: aSection [
-	self visitDocumentGroup: aSection
+	^ self visitDocumentGroup: aSection
 ]
 
 { #category : #'visiting-document' }
 PRVisitor >> visitStrikethroughFormat: anObject [
-	self visitFormat: anObject
+	^ self visitFormat: anObject
 ]
 
 { #category : #'visiting-document' }
 PRVisitor >> visitSubscriptFormat: anObject [
-	self visitFormat: anObject
+	^ self visitFormat: anObject
 ]
 
 { #category : #'visiting-document' }
 PRVisitor >> visitSuperscriptFormat: anObject [
-	self visitFormat: anObject
+	^ self visitFormat: anObject
 ]
 
 { #category : #'visiting-document' }
 PRVisitor >> visitTermItem: anObject [
-	self visitListItem: anObject
+	^ self visitListItem: anObject
 ]
 
 { #category : #'visiting-document' }
 PRVisitor >> visitText: anObject [
-	self visitDocumentItem: anObject
+	^ self visitDocumentItem: anObject
 ]
 
 { #category : #'visiting-annotations' }
@@ -252,10 +252,10 @@ PRVisitor >> visitUndefinedAnnotation: aUndefinedAnnotation [
 
 { #category : #'visiting-document' }
 PRVisitor >> visitUnderlineFormat: anObject [
-	self visitFormat: anObject
+	^ self visitFormat: anObject
 ]
 
 { #category : #'visiting-document' }
 PRVisitor >> visitUnorderedList: anObject [
-	self visitList: anObject
+	^ self visitList: anObject
 ]

--- a/src/Pillar-Model/PRAnnotatedParagraph.class.st
+++ b/src/Pillar-Model/PRAnnotatedParagraph.class.st
@@ -7,7 +7,7 @@ Class {
 	#instVars : [
 		'annotation'
 	],
-	#category : 'Pillar-Model-Document'
+	#category : #'Pillar-Model-Document'
 }
 
 { #category : #'instance creation' }
@@ -24,7 +24,7 @@ PRAnnotatedParagraph >> = anObject [
 
 { #category : #visiting }
 PRAnnotatedParagraph >> accept: aVisitor [
-	aVisitor visitAnnotatedParagraph: self
+	^ aVisitor visitAnnotatedParagraph: self
 ]
 
 { #category : #accessing }

--- a/src/Pillar-Model/PRBeginColumnsAnnotation.class.st
+++ b/src/Pillar-Model/PRBeginColumnsAnnotation.class.st
@@ -38,5 +38,5 @@ PRBeginColumnsAnnotation class >> tag [
 
 { #category : #visiting }
 PRBeginColumnsAnnotation >> accept: aVisitor [
-	aVisitor visitColumnsAnnotation: self
+	^ aVisitor visitColumnsAnnotation: self
 ]

--- a/src/Pillar-Model/PRCitation.class.st
+++ b/src/Pillar-Model/PRCitation.class.st
@@ -11,7 +11,7 @@ Class {
 		'hadAllKeys',
 		'ref'
 	],
-	#category : 'Pillar-Model-Document'
+	#category : #'Pillar-Model-Document'
 }
 
 { #category : #'as yet unclassified' }
@@ -38,7 +38,7 @@ PRCitation >> = anObject [
 
 { #category : #visiting }
 PRCitation >> accept: aVisitor [
-	aVisitor visitCitation: self
+	^ aVisitor visitCitation: self
 ]
 
 { #category : #initialization }

--- a/src/Pillar-Model/PRCitationAnnotation.class.st
+++ b/src/Pillar-Model/PRCitationAnnotation.class.st
@@ -12,7 +12,7 @@ Examples:
 Class {
 	#name : #PRCitationAnnotation,
 	#superclass : #PRAbstractAnnotation,
-	#category : 'Pillar-Model-Document'
+	#category : #'Pillar-Model-Document'
 }
 
 { #category : #accessing }
@@ -28,7 +28,7 @@ PRCitationAnnotation class >> tag [
 { #category : #visiting }
 PRCitationAnnotation >> accept: aVisitor [
 
-	aVisitor visitCitationAnnotation: self
+	^ aVisitor visitCitationAnnotation: self
 ]
 
 { #category : #printing }

--- a/src/Pillar-Model/PRColumn.class.st
+++ b/src/Pillar-Model/PRColumn.class.st
@@ -7,7 +7,7 @@ Class {
 	#instVars : [
 		'width'
 	],
-	#category : 'Pillar-Model-Document'
+	#category : #'Pillar-Model-Document'
 }
 
 { #category : #testing }
@@ -24,7 +24,7 @@ PRColumn class >> width: aNumber [
 
 { #category : #visiting }
 PRColumn >> accept: aVisitor [
-	aVisitor visitColumn: self
+	^ aVisitor visitColumn: self
 ]
 
 { #category : #accessing }

--- a/src/Pillar-Model/PRColumnAnnotation.class.st
+++ b/src/Pillar-Model/PRColumnAnnotation.class.st
@@ -35,7 +35,7 @@ ${endColumns}$
 Class {
 	#name : #PRColumnAnnotation,
 	#superclass : #PRAbstractAnnotation,
-	#category : 'Pillar-Model-Document'
+	#category : #'Pillar-Model-Document'
 }
 
 { #category : #accessing }
@@ -50,7 +50,7 @@ PRColumnAnnotation class >> tag [
 
 { #category : #visiting }
 PRColumnAnnotation >> accept: aVisitor [
-	aVisitor visitColumnAnnotation: self
+	^ aVisitor visitColumnAnnotation: self
 ]
 
 { #category : #printing }

--- a/src/Pillar-Model/PRColumnEnvironment.class.st
+++ b/src/Pillar-Model/PRColumnEnvironment.class.st
@@ -14,5 +14,5 @@ PRColumnEnvironment class >> isAbstract [
 
 { #category : #visiting }
 PRColumnEnvironment >> accept: aVisitor [
-	aVisitor visitColumns: self
+	^ aVisitor visitColumns: self
 ]

--- a/src/Pillar-Model/PRCommentedLine.class.st
+++ b/src/Pillar-Model/PRCommentedLine.class.st
@@ -4,10 +4,10 @@ A commented line
 Class {
 	#name : #PRCommentedLine,
 	#superclass : #PRText,
-	#category : 'Pillar-Model-Document'
+	#category : #'Pillar-Model-Document'
 }
 
 { #category : #visiting }
 PRCommentedLine >> accept: aVisitor [
-	aVisitor visitCommentedLine: self
+	^ aVisitor visitCommentedLine: self
 ]

--- a/src/Pillar-Model/PRDataItem.class.st
+++ b/src/Pillar-Model/PRDataItem.class.st
@@ -4,10 +4,10 @@ Data in a list
 Class {
 	#name : #PRDataItem,
 	#superclass : #PRListItem,
-	#category : 'Pillar-Model-Document'
+	#category : #'Pillar-Model-Document'
 }
 
 { #category : #visiting }
 PRDataItem >> accept: aVisitor [
-	aVisitor visitDataItem: self
+	^ aVisitor visitDataItem: self
 ]

--- a/src/Pillar-Model/PRDefinitionList.class.st
+++ b/src/Pillar-Model/PRDefinitionList.class.st
@@ -4,7 +4,7 @@ I am an definition list. I am typically used for a keyword and a longer definiti
 Class {
 	#name : #PRDefinitionList,
 	#superclass : #PRList,
-	#category : 'Pillar-Model-Document'
+	#category : #'Pillar-Model-Document'
 }
 
 { #category : #testing }
@@ -14,5 +14,5 @@ PRDefinitionList class >> isAbstract [
 
 { #category : #visiting }
 PRDefinitionList >> accept: aVisitor [
-	aVisitor visitDefinitionList: self
+	^ aVisitor visitDefinitionList: self
 ]

--- a/src/Pillar-Model/PRDocumentListAnnotation.class.st
+++ b/src/Pillar-Model/PRDocumentListAnnotation.class.st
@@ -34,7 +34,7 @@ PRDocumentListAnnotation class >> tag [
 { #category : #visiting }
 PRDocumentListAnnotation >> accept: aVisitor [
 
-	aVisitor visitDocListAnnotation: self
+	^ aVisitor visitDocListAnnotation: self
 ]
 
 { #category : #visiting }

--- a/src/Pillar-Model/PREndColumnsAnnotation.class.st
+++ b/src/Pillar-Model/PREndColumnsAnnotation.class.st
@@ -38,5 +38,5 @@ PREndColumnsAnnotation class >> tag [
 
 { #category : #visiting }
 PREndColumnsAnnotation >> accept: aVisitor [
-	aVisitor visitEndColumnsAnnotation: self
+	^ aVisitor visitEndColumnsAnnotation: self
 ]

--- a/src/Pillar-Model/PRFootnote.class.st
+++ b/src/Pillar-Model/PRFootnote.class.st
@@ -11,7 +11,7 @@ Class {
 	#instVars : [
 		'note'
 	],
-	#category : 'Pillar-Model-Document'
+	#category : #'Pillar-Model-Document'
 }
 
 { #category : #testing }
@@ -26,7 +26,7 @@ PRFootnote class >> noted: aString [
 
 { #category : #visiting }
 PRFootnote >> accept: aVisitor [
-	aVisitor visitFootnote: self.
+	^ aVisitor visitFootnote: self.
 ]
 
 { #category : #accessing }

--- a/src/Pillar-Model/PRFootnoteAnnotation.class.st
+++ b/src/Pillar-Model/PRFootnoteAnnotation.class.st
@@ -10,7 +10,7 @@ My parameters are :
 Class {
 	#name : #PRFootnoteAnnotation,
 	#superclass : #PRAbstractAnnotation,
-	#category : 'Pillar-Model-Document'
+	#category : #'Pillar-Model-Document'
 }
 
 { #category : #accessing }
@@ -26,7 +26,7 @@ PRFootnoteAnnotation class >> tag [
 
 { #category : #visiting }
 PRFootnoteAnnotation >> accept: aVisitor [
-	aVisitor visitFootnoteAnnotation: self
+	^ aVisitor visitFootnoteAnnotation: self
 ]
 
 { #category : #descriptions }

--- a/src/Pillar-Model/PRHorizontalRule.class.st
+++ b/src/Pillar-Model/PRHorizontalRule.class.st
@@ -4,7 +4,7 @@ I am a horizontal rule.
 Class {
 	#name : #PRHorizontalRule,
 	#superclass : #PRDocumentItem,
-	#category : 'Pillar-Model-Document'
+	#category : #'Pillar-Model-Document'
 }
 
 { #category : #testing }
@@ -14,5 +14,5 @@ PRHorizontalRule class >> isAbstract [
 
 { #category : #visiting }
 PRHorizontalRule >> accept: aVisitor [
-	aVisitor visitHorizontalRule: self
+	^ aVisitor visitHorizontalRule: self
 ]

--- a/src/Pillar-Model/PRInputFileAnnotation.class.st
+++ b/src/Pillar-Model/PRInputFileAnnotation.class.st
@@ -15,7 +15,7 @@ ${inputFile:value=directory/myFile.pillar}$
 Class {
 	#name : #PRInputFileAnnotation,
 	#superclass : #PRAbstractAnnotation,
-	#category : 'Pillar-Model-Document'
+	#category : #'Pillar-Model-Document'
 }
 
 { #category : #protected }
@@ -48,7 +48,7 @@ PRInputFileAnnotation class >> value: aValue [
 
 { #category : #visiting }
 PRInputFileAnnotation >> accept: aVisitor [
-	aVisitor visitInputFileAnnotation: self
+	^ aVisitor visitInputFileAnnotation: self
 ]
 
 { #category : #printing }

--- a/src/Pillar-Model/PRRaw.class.st
+++ b/src/Pillar-Model/PRRaw.class.st
@@ -9,7 +9,7 @@ Class {
 	#instVars : [
 		'type'
 	],
-	#category : 'Pillar-Model-Document'
+	#category : #'Pillar-Model-Document'
 }
 
 { #category : #'instance creation' }
@@ -38,7 +38,7 @@ PRRaw >> = anObject [
 
 { #category : #visiting }
 PRRaw >> accept: aVisitor [
-	aVisitor visitRaw: self
+	^ aVisitor visitRaw: self
 ]
 
 { #category : #comparing }

--- a/src/Pillar-Model/PRSlide.class.st
+++ b/src/Pillar-Model/PRSlide.class.st
@@ -12,7 +12,7 @@ Class {
 		'title',
 		'label'
 	],
-	#category : 'Pillar-Model-Document'
+	#category : #'Pillar-Model-Document'
 }
 
 { #category : #testing }
@@ -29,7 +29,7 @@ PRSlide class >> titled: aTitle [
 
 { #category : #visiting }
 PRSlide >> accept: aVisitor [
-	aVisitor visitSlide: self
+	^ aVisitor visitSlide: self
 ]
 
 { #category : #testing }

--- a/src/Pillar-Model/PRSlideTitleAnnotation.class.st
+++ b/src/Pillar-Model/PRSlideTitleAnnotation.class.st
@@ -19,7 +19,7 @@ ${slide:title=Conclusion|label=sld:ccl}$
 Class {
 	#name : #PRSlideTitleAnnotation,
 	#superclass : #PRAbstractAnnotation,
-	#category : 'Pillar-Model-Document'
+	#category : #'Pillar-Model-Document'
 }
 
 { #category : #accessing }
@@ -35,5 +35,5 @@ PRSlideTitleAnnotation class >> tag [
 
 { #category : #visiting }
 PRSlideTitleAnnotation >> accept: aVisitor [
-	aVisitor visitSlideTitleAnnotation: self
+	^ aVisitor visitSlideTitleAnnotation: self
 ]

--- a/src/Pillar-Model/PRStrikethroughFormat.class.st
+++ b/src/Pillar-Model/PRStrikethroughFormat.class.st
@@ -14,5 +14,5 @@ PRStrikethroughFormat class >> isAbstract [
 
 { #category : #visiting }
 PRStrikethroughFormat >> accept: aVisitor [
-	aVisitor visitStrikethroughFormat: self
+	^ aVisitor visitStrikethroughFormat: self
 ]

--- a/src/Pillar-Model/PRSubscriptFormat.class.st
+++ b/src/Pillar-Model/PRSubscriptFormat.class.st
@@ -14,5 +14,5 @@ PRSubscriptFormat class >> isAbstract [
 
 { #category : #visiting }
 PRSubscriptFormat >> accept: aVisitor [
-	aVisitor visitSubscriptFormat: self
+	^ aVisitor visitSubscriptFormat: self
 ]

--- a/src/Pillar-Model/PRSuperscriptFormat.class.st
+++ b/src/Pillar-Model/PRSuperscriptFormat.class.st
@@ -4,7 +4,7 @@ Style as superscript
 Class {
 	#name : #PRSuperscriptFormat,
 	#superclass : #PRFormat,
-	#category : 'Pillar-Model-Document'
+	#category : #'Pillar-Model-Document'
 }
 
 { #category : #testing }
@@ -14,5 +14,5 @@ PRSuperscriptFormat class >> isAbstract [
 
 { #category : #visiting }
 PRSuperscriptFormat >> accept: aVisitor [
-	aVisitor visitSuperscriptFormat: self
+	^ aVisitor visitSuperscriptFormat: self
 ]

--- a/src/Pillar-Model/PRTable.class.st
+++ b/src/Pillar-Model/PRTable.class.st
@@ -4,7 +4,7 @@ I am a table. My children are instances of *PRTableRow*.
 Class {
 	#name : #PRTable,
 	#superclass : #PRDocumentGroup,
-	#category : 'Pillar-Model-Document'
+	#category : #'Pillar-Model-Document'
 }
 
 { #category : #testing }
@@ -14,7 +14,7 @@ PRTable class >> isAbstract [
 
 { #category : #visiting }
 PRTable >> accept: aVisitor [
-	aVisitor visitTable: self
+	^ aVisitor visitTable: self
 ]
 
 { #category : #accessing }

--- a/src/Pillar-Model/PRTableCell.class.st
+++ b/src/Pillar-Model/PRTableCell.class.st
@@ -8,7 +8,7 @@ Class {
 		'align',
 		'heading'
 	],
-	#category : 'Pillar-Model-Document'
+	#category : #'Pillar-Model-Document'
 }
 
 { #category : #'instance creation' }
@@ -33,7 +33,7 @@ PRTableCell >> = anObject [
 
 { #category : #visiting }
 PRTableCell >> accept: aVisitor [
-	aVisitor visitTableCell: self
+	^ aVisitor visitTableCell: self
 ]
 
 { #category : #accessing }

--- a/src/Pillar-Model/PRTableRow.class.st
+++ b/src/Pillar-Model/PRTableRow.class.st
@@ -4,7 +4,7 @@ I am a row of a table. My children are instances of *PRTableCell*.
 Class {
 	#name : #PRTableRow,
 	#superclass : #PRDocumentGroup,
-	#category : 'Pillar-Model-Document'
+	#category : #'Pillar-Model-Document'
 }
 
 { #category : #testing }
@@ -14,7 +14,7 @@ PRTableRow class >> isAbstract [
 
 { #category : #visiting }
 PRTableRow >> accept: aVisitor [
-	aVisitor visitTableRow: self
+	^ aVisitor visitTableRow: self
 ]
 
 { #category : #accessing }

--- a/src/Pillar-Model/PRTermItem.class.st
+++ b/src/Pillar-Model/PRTermItem.class.st
@@ -16,10 +16,10 @@ color of the fire
 Class {
 	#name : #PRTermItem,
 	#superclass : #PRListItem,
-	#category : 'Pillar-Model-Document'
+	#category : #'Pillar-Model-Document'
 }
 
 { #category : #visiting }
 PRTermItem >> accept: aVisitor [
-	aVisitor visitTermItem: self
+	^ aVisitor visitTermItem: self
 ]

--- a/src/Pillar-Model/PRTocAnnotation.class.st
+++ b/src/Pillar-Model/PRTocAnnotation.class.st
@@ -21,7 +21,7 @@ ${toc:depthLevel=5|level=3|highlight=true}$
 Class {
 	#name : #PRTocAnnotation,
 	#superclass : #PRAbstractAnnotation,
-	#category : 'Pillar-Model-Document'
+	#category : #'Pillar-Model-Document'
 }
 
 { #category : #accessing }
@@ -36,5 +36,5 @@ PRTocAnnotation class >> tag [
 
 { #category : #visiting }
 PRTocAnnotation >> accept: aVisitor [
-	aVisitor visitTOCAnnotation: self
+	^ aVisitor visitTOCAnnotation: self
 ]

--- a/src/Pillar-Model/PRUnderlineFormat.class.st
+++ b/src/Pillar-Model/PRUnderlineFormat.class.st
@@ -4,7 +4,7 @@ Style as underline formatted
 Class {
 	#name : #PRUnderlineFormat,
 	#superclass : #PRFormat,
-	#category : 'Pillar-Model-Document'
+	#category : #'Pillar-Model-Document'
 }
 
 { #category : #testing }
@@ -14,5 +14,5 @@ PRUnderlineFormat class >> isAbstract [
 
 { #category : #visiting }
 PRUnderlineFormat >> accept: aVisitor [
-	aVisitor visitUnderlineFormat: self
+	^ aVisitor visitUnderlineFormat: self
 ]

--- a/src/Pillar-Model/PRUnorderedList.class.st
+++ b/src/Pillar-Model/PRUnorderedList.class.st
@@ -4,7 +4,7 @@ I am an unordered list. I am typically used for unnumbered lists
 Class {
 	#name : #PRUnorderedList,
 	#superclass : #PRList,
-	#category : 'Pillar-Model-Document'
+	#category : #'Pillar-Model-Document'
 }
 
 { #category : #testing }
@@ -14,5 +14,5 @@ PRUnorderedList class >> isAbstract [
 
 { #category : #visiting }
 PRUnorderedList >> accept: aVisitor [
-	aVisitor visitUnorderedList: self
+	^ aVisitor visitUnorderedList: self
 ]

--- a/src/Pillar-Model/PRVisitor.extension.st
+++ b/src/Pillar-Model/PRVisitor.extension.st
@@ -2,96 +2,96 @@ Extension { #name : #PRVisitor }
 
 { #category : #'*Pillar-Model' }
 PRVisitor >> visitCitation: aCitation [
-	self visitDocumentItem: aCitation
+	^ self visitDocumentItem: aCitation
 ]
 
 { #category : #'*Pillar-Model' }
 PRVisitor >> visitCitationAnnotation: aCitation [
 	"Visiting an annotation means that we visit the textual representation of an annotation. Such annotations will be transformed into annotation object. The corresponding visit method will be invoked on such object : visitCitationAnnotation vs visitCitation."
-	self visitAnnotation: aCitation
+	^ self visitAnnotation: aCitation
 ]
 
 { #category : #'*Pillar-Model' }
 PRVisitor >> visitColumn: aColumn [
-	self visitDocumentGroup: aColumn
+	^ self visitDocumentGroup: aColumn
 ]
 
 { #category : #'*Pillar-Model' }
 PRVisitor >> visitColumnAnnotation: aColumnAnnotation [
 	"Visiting an annotation means that we visit the textual representation of an annotation. Such annotations will be transformed into annotation object. The corresponding visit method will be invoked on such object : visitColumnAnnotation vs visitColumn."
-	self visitAnnotation: aColumnAnnotation
+	^ self visitAnnotation: aColumnAnnotation
 ]
 
 { #category : #'*Pillar-Model' }
 PRVisitor >> visitColumns: aColumns [
-	self visitDocumentGroup: aColumns
+	^ self visitDocumentGroup: aColumns
 ]
 
 { #category : #'*Pillar-Model' }
 PRVisitor >> visitColumnsAnnotation: aColumnsAnnotation [
 	"Visiting an annotation means that we visit the textual representation of an annotation. Such annotations will be transformed into annotation object. The corresponding visit method will be invoked on such object : visitColumnsAnnotation vs visitColumns."
-	self visitAnnotation: aColumnsAnnotation
+	^ self visitAnnotation: aColumnsAnnotation
 ]
 
 { #category : #'*Pillar-Model' }
 PRVisitor >> visitDocListAnnotation: aPRDocListAnnotation [ 
-	self visitAnnotation: aPRDocListAnnotation
+	^ self visitAnnotation: aPRDocListAnnotation
 ]
 
 { #category : #'*Pillar-Model' }
 PRVisitor >> visitEndColumnsAnnotation: aEndColumnsAnnotation [
-	self visitAnnotation: aEndColumnsAnnotation
+	^ self visitAnnotation: aEndColumnsAnnotation
 ]
 
 { #category : #'*Pillar-Model' }
 PRVisitor >> visitEndEnvironmentAnnotation: aEndEnvironmentAnnotation [
 	"Visiting an annotation means that we visit the textual representation of an annotation. Such annotations will be transformed into annotation object. The corresponding visit method will be invoked on such object : visitBeginEnvironmentAnnotation vs visitBeginEnvironment."
-	self visitAnnotation: aEndEnvironmentAnnotation
+	^ self visitAnnotation: aEndEnvironmentAnnotation
 ]
 
 { #category : #'*Pillar-Model' }
 PRVisitor >> visitFootnote: aFootnote [
-	self visitDocumentItem: aFootnote
+	^ self visitDocumentItem: aFootnote
 ]
 
 { #category : #'*Pillar-Model' }
 PRVisitor >> visitFootnoteAnnotation: aFootnoteAnnotation [
 	"Visiting an annotation means that we visit the textual representation of an annotation. Such annotations will be transformed into annotation object. The corresponding visit method will be invoked on such object : visitFootnoteAnnotation vs visitFootnote."
-	self visitAnnotation: aFootnoteAnnotation
+	^ self visitAnnotation: aFootnoteAnnotation
 ]
 
 { #category : #'*Pillar-Model' }
 PRVisitor >> visitInputFileAnnotation: anInputFileAnnotation [
-	self visitAnnotation: anInputFileAnnotation
+	^ self visitAnnotation: anInputFileAnnotation
 ]
 
 { #category : #'*Pillar-Model' }
 PRVisitor >> visitSlide: aSlide [
-	self visitDocumentGroup: aSlide
+	^ self visitDocumentGroup: aSlide
 ]
 
 { #category : #'*Pillar-Model' }
 PRVisitor >> visitSlideTitleAnnotation: aSlideTitleAnnotation [
 	"Visiting an annotation means that we visit the textual representation of an annotation. Such annotations will be transformed into annotation object. The corresponding visit method will be invoked on such object : visitSlideTitleAnnotation vs visitSlide."
-	self visitAnnotation: aSlideTitleAnnotation
+	^ self visitAnnotation: aSlideTitleAnnotation
 ]
 
 { #category : #'*Pillar-Model' }
 PRVisitor >> visitTOCAnnotation: aTOCAnnotation [
-	self visitAnnotation: aTOCAnnotation
+	^ self visitAnnotation: aTOCAnnotation
 ]
 
 { #category : #'*Pillar-Model' }
 PRVisitor >> visitTable: anObject [
-	self visitDocumentGroup: anObject
+	^ self visitDocumentGroup: anObject
 ]
 
 { #category : #'*Pillar-Model' }
 PRVisitor >> visitTableCell: anObject [
-	self visitDocumentGroup: anObject
+	^ self visitDocumentGroup: anObject
 ]
 
 { #category : #'*Pillar-Model' }
 PRVisitor >> visitTableRow: anObject [
-	self visitDocumentGroup: anObject
+	^ self visitDocumentGroup: anObject
 ]


### PR DESCRIPTION
Fixes #389 - adds return visitors and accept

I hope this one is better. I would like to learn how to run all the tests locally, but so many new things yet to pick-up.

Done using this rewrite script:
```Smalltalk
(PRVisitor methodDict keys select: [ :sel | sel beginsWith: 'visit'])
do: [ :sel | 
	|source cat|
	source := (PRVisitor >> sel) sourceCode copyReplaceAll: '	self' with: '	^ self'.
	cat := (PRVisitor >> sel) protocol asString.
	PRVisitor compile: source classified: cat.
	].

((PRDocumentItem allSubclasses ,{PRDocumentItem}) select: [:cl | cl includesSelector:  #accept:]) 
do: [ :docClass | 
	|source cat|
	source := (docClass >> #accept:) sourceCode copyReplaceAll: '	aVisitor' with: '	^ aVisitor'.
	cat := (docClass >> #accept:) protocol asString.
	docClass compile: source classified: cat.
	].
```

and added return to the `start:`method in `PRVisitor` by hand.