### PR TITLE
392-Baseline-of-Pillar-Core-does-not-load-Pillar-Core

### DIFF
--- a/src/BaselineOfPillarCore/BaselineOfPillarCore.class.st
+++ b/src/BaselineOfPillarCore/BaselineOfPillarCore.class.st
@@ -16,7 +16,7 @@ BaselineOfPillarCore >> baseline: spec [
 					repository: 'github://Ducasse/Containers-PropertyEnvironment' ];
 				baseline: 'PetitParser2Core' with: [ spec
 					 repository: 'github://kursjan/petitparser2' ];
-
+				package: 'Pillar-Core';
 				package: 'Pillar-Model';
 				package: 'Pillar-PetitPillar' with: [ spec 
 					requires: #( 'PetitParser2Core' 'Pillar-Model' ) ];


### PR DESCRIPTION
Fixes #392

Added package instruction to 'BaselineOfPillarCore' to load 'Pillar-Core'.