### PR TITLE
Fix dependencies package required by the latex book temp

### DIFF
--- a/scripts/ci/ensure_book_dependencies.sh
+++ b/scripts/ci/ensure_book_dependencies.sh
@@ -12,4 +12,4 @@ tlmgr install trimspaces
 tlmgr install ctablestack
 tlmgr install import
 tlmgr install multirow
-tlmgr install ifetex
+tlmgr install iftex


### PR DESCRIPTION
#### Description 
- Fix dependencies package required by the latex book temp. 
- The ifetex package is now part of iftex.
