### PR TITLE
Add flags -a, -m for build command line

### DIFF
--- a/src/Pillar-Cli/PRBuildCommandLineHandler.class.st
+++ b/src/Pillar-Cli/PRBuildCommandLineHandler.class.st
@@ -7,6 +7,11 @@ To build a book pdf
 
 To use a template
 ./pharo-ui Pillar.image pillar build --templatable html
+
+To use a specific build strategy:
+pillar build -a pdf >> build all Pillar documents found in directory
+pillar build -m pdf >> default build, only index.pillar is build
+NOTE: there is no flag for ""list"" as buildList is called only if files are given as positionals after format
 "
 Class {
 	#name : #PRBuildCommandLineHandler,
@@ -29,6 +34,10 @@ PRBuildCommandLineHandler >> activate [
 		ifNotEmpty: [ :files | target buildOnly: files ].
 	(self hasOption: 'templatable')
 		ifTrue: [ self project beTemplatable ].
+	(self hasOption: 'a')
+		ifTrue: [ target buildAll ].
+	(self hasOption: 'm')
+		ifTrue: [ target buildMainRoot ].
 	result := self project build: target.
 	result exitProcess
 ]


### PR DESCRIPTION
pillar build pdf -a >> for building all Pillar docs
pillar build pdf -m >> for building only index.pillar (mainRoot)

mainRoot is called by default
