### PR TITLE
Changing PRBuildRootMainStrategy >> filesToBuildOn:

### DIFF
--- a/src/Pillar-ExporterCore/PRBuildRootMainStrategy.class.st
+++ b/src/Pillar-ExporterCore/PRBuildRootMainStrategy.class.st
@@ -12,14 +12,14 @@ Class {
 
 { #category : #accessing }
 PRBuildRootMainStrategy >> filesToBuildOn: aProject [ 
+	"select the only file with pillar extension in current directory ; if there is no OR several pillar files, relative error is raised"
 	
-	| file |
-	file := aProject baseDirectory children detect: [ :each | each isFile and: [ each extension = 'pillar' ] ] ifNone: [ self error: 'There is no file pillar on the reposittory root.' ].
-	"we should set up an infrastructure to cleaning report problems.
-	may via aProject"
-	^ { PRInputDocument new
+	| pillarFiles|
+	pillarFiles := aProject baseDirectory children select: [ :each | each isFile and: [ each extension = 'pillar' ] ].
+	pillarFiles ifEmpty: [ self error: 'There is no pillar file in the repository root.' ].
+	pillarFiles size = 1 ifTrue: [ ^ { PRInputDocument new
 			project: aProject;
-			file: file;
-			yourself }
-	
+			file: pillarFiles first;
+			yourself } ].
+	self error: 'There is more than one pillar file in the repository root.'
 ]

--- a/src/Pillar-Tests-ExporterCore/PRBuildRootMainStrategyTest.class.st
+++ b/src/Pillar-Tests-ExporterCore/PRBuildRootMainStrategyTest.class.st
@@ -1,0 +1,25 @@
+Class {
+	#name : #PRBuildRootMainStrategyTest,
+	#superclass : #PRBuildStrategyTest,
+	#category : #'Pillar-Tests-ExporterCore-Base'
+}
+
+{ #category : #tests }
+PRBuildRootMainStrategyTest >> testFilesToBuildOnCorrect [
+	| outputProject |
+	outputProject := PRBuildRootMainStrategy new filesToBuildOn: project.
+	self assert: outputProject first class equals: PRInputDocument.
+	self assert: outputProject first file path equals: Path / 'index.pillar'
+]
+
+{ #category : #tests }
+PRBuildRootMainStrategyTest >> testFilesToBuildOnErrorNoFile [
+	project baseDirectory: ((project baseDirectory / 'index.pillar') delete; parent).
+	self should: [ PRBuildRootMainStrategy new filesToBuildOn: project ] raise: Error
+]
+
+{ #category : #tests }
+PRBuildRootMainStrategyTest >> testFilesToBuildOnErrorSeveralFiles [
+	project baseDirectory: ((project baseDirectory / 'chap3.pillar') ensureCreateFile; parent).
+	self should: [ PRBuildRootMainStrategy new filesToBuildOn: project ] raise: Error
+]


### PR DESCRIPTION
To raise error when there is no or serveral pillar docs in current directory
+ writing relative tests