### PR TITLE
CLAP new format export: ascii & markdown

### DIFF
--- a/src/Pillar-ExporterAsciiDoc/PRAsciiOutput.class.st
+++ b/src/Pillar-ExporterAsciiDoc/PRAsciiOutput.class.st
@@ -1,0 +1,33 @@
+Class {
+	#name : #PRAsciiOutput,
+	#superclass : #PRWritingTarget,
+	#category : #'Pillar-ExporterAsciiDoc'
+}
+
+{ #category : #building }
+PRAsciiOutput >> documentFor: aFile [
+
+	^ PRAsciiDocument new
+		project: aFile project;
+		file: aFile;
+		target: self;
+		outputDirectory: aFile project outputDirectory / self extension;
+		yourself
+]
+
+{ #category : #accessing }
+PRAsciiOutput >> extension [
+	^ 'ascii'
+]
+
+{ #category : #accessing }
+PRAsciiOutput >> outputDirectoryName [
+	
+	^ 'ascii'
+]
+
+{ #category : #accessing }
+PRAsciiOutput >> writerFor: aPRPillarConfiguration [ 
+	
+	^ PRAsciiDocWriter new
+]

--- a/src/Pillar-ExporterAsciiDoc/PRAsciiOutput.class.st
+++ b/src/Pillar-ExporterAsciiDoc/PRAsciiOutput.class.st
@@ -4,6 +4,11 @@ Class {
 	#category : #'Pillar-ExporterAsciiDoc'
 }
 
+{ #category : #accessing }
+PRAsciiOutput class >> builderName [
+	^ 'ascii'
+]
+
 { #category : #building }
 PRAsciiOutput >> documentFor: aFile [
 

--- a/src/Pillar-ExporterCore/PRWritingTarget.class.st
+++ b/src/Pillar-ExporterCore/PRWritingTarget.class.st
@@ -6,7 +6,7 @@ Class {
 
 { #category : #accessing }
 PRWritingTarget class >> builderName [
-	^ 'writingTarget'
+	^ self subclassResponsibility 
 ]
 
 { #category : #testing }

--- a/src/Pillar-ExporterHTML/PRMarkdownOutput.class.st
+++ b/src/Pillar-ExporterHTML/PRMarkdownOutput.class.st
@@ -1,0 +1,33 @@
+Class {
+	#name : #PRMarkdownOutput,
+	#superclass : #PRWritingTarget,
+	#category : #'Pillar-ExporterHTML'
+}
+
+{ #category : #building }
+PRMarkdownOutput >> documentFor: aFile [
+
+	^ PRMarkdownDocument new
+		project: aFile project;
+		file: aFile;
+		target: self;
+		outputDirectory: aFile project outputDirectory / self extension;
+		yourself
+]
+
+{ #category : #accessing }
+PRMarkdownOutput >> extension [
+	^ 'markdown'
+]
+
+{ #category : #accessing }
+PRMarkdownOutput >> outputDirectoryName [
+	
+	^ 'markdown'
+]
+
+{ #category : #accessing }
+PRMarkdownOutput >> writerFor: aPRPillarConfiguration [ 
+	
+	^ PRMarkdownWriter new
+]

--- a/src/Pillar-ExporterMarkdown/PRMarkdownOutput.class.st
+++ b/src/Pillar-ExporterMarkdown/PRMarkdownOutput.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #PRMarkdownOutput,
 	#superclass : #PRWritingTarget,
-	#category : #'Pillar-ExporterHTML'
+	#category : #'Pillar-ExporterMarkdown'
 }
 
 { #category : #building }

--- a/src/Pillar-ExporterMarkdown/PRMarkdownOutput.class.st
+++ b/src/Pillar-ExporterMarkdown/PRMarkdownOutput.class.st
@@ -4,6 +4,11 @@ Class {
 	#category : #'Pillar-ExporterMarkdown'
 }
 
+{ #category : #accessing }
+PRMarkdownOutput class >> builderName [
+	^ 'markdown'
+]
+
 { #category : #building }
 PRMarkdownOutput >> documentFor: aFile [
 

--- a/src/Pillar-ExporterText/PRAsciiDocument.class.st
+++ b/src/Pillar-ExporterText/PRAsciiDocument.class.st
@@ -1,15 +1,15 @@
 Class {
-	#name : #PRMarkdownDocument,
+	#name : #PRAsciiDocument,
 	#superclass : #PRTextDocument,
 	#category : #'Pillar-ExporterText'
 }
 
 { #category : #accessing }
-PRMarkdownDocument >> basicWriter [
-	^ PRMarkdownWriter new
+PRAsciiDocument >> basicWriter [
+	^ PRAsciiDocWriter new
 ]
 
 { #category : #accessing }
-PRMarkdownDocument >> extension [
-	^ 'markdown'
+PRAsciiDocument >> extension [
+	^ 'ascii'
 ]

--- a/src/Pillar-ExporterText/PRMarkdownDocument.class.st
+++ b/src/Pillar-ExporterText/PRMarkdownDocument.class.st
@@ -13,3 +13,18 @@ PRMarkdownDocument >> basicWriter [
 PRMarkdownDocument >> extension [
 	^ 'markdown'
 ]
+
+{ #category : #building }
+PRMarkdownDocument >> writeDocument: aDocument [
+
+	| outputContent outputFile |
+	outputContent := self basicWriter write: aDocument.
+	
+	
+	self flag: #DuplicatedInSubclass.
+	outputFile := (self outputDirectory resolve: (file file asAbsolute relativeTo: project baseDirectory asAbsolute)) withoutExtension , self extension.
+	outputFile ensureDelete.
+	outputFile parent ensureCreateDirectory.
+	outputFile writeStreamDo: [ :stream | stream nextPutAll: outputContent ].
+	^ outputFile
+]

--- a/src/Pillar-ExporterText/PRMarkdownDocument.class.st
+++ b/src/Pillar-ExporterText/PRMarkdownDocument.class.st
@@ -1,0 +1,15 @@
+Class {
+	#name : #PRMarkdownDocument,
+	#superclass : #PRTextDocument,
+	#category : #'Pillar-ExporterText'
+}
+
+{ #category : #accessing }
+PRMarkdownDocument >> basicWriter [
+	^ PRMarkdownWriter new
+]
+
+{ #category : #accessing }
+PRMarkdownDocument >> extension [
+	^ 'markdown'
+]

--- a/src/Pillar-ExporterText/PRTextDocument.class.st
+++ b/src/Pillar-ExporterText/PRTextDocument.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #PRTextDocument,
 	#superclass : #PRAbstractOutputDocument,
-	#category : 'Pillar-ExporterText'
+	#category : #'Pillar-ExporterText'
 }
 
 { #category : #accessing }
@@ -14,4 +14,19 @@ PRTextDocument >> basicWriter [
 PRTextDocument >> extension [
 	
 	^ 'txt'
+]
+
+{ #category : #building }
+PRTextDocument >> writeDocument: aDocument [
+
+	| outputContent outputFile |
+	outputContent := self basicWriter write: aDocument.
+	
+	
+	self flag: #DuplicatedInSubclass.
+	outputFile := (self outputDirectory resolve: (file file asAbsolute relativeTo: project baseDirectory asAbsolute)) withoutExtension , self extension.
+	outputFile ensureDelete.
+	outputFile parent ensureCreateDirectory.
+	outputFile writeStreamDo: [ :stream | stream nextPutAll: outputContent ].
+	^ outputFile
 ]

--- a/src/Pillar-Tests-Integration/PRIntegrationTest.class.st
+++ b/src/Pillar-Tests-Integration/PRIntegrationTest.class.st
@@ -171,7 +171,7 @@ PRIntegrationTest >> testWelcomeHtml [
 PRIntegrationTest >> testWelcomeMarkdown [
 
 	self testArchetype: self archetypeWelcome output: self outputMarkdown.
-	self assert: (project outputDirectory / 'markdown' / 'index.markdown') exists.
+	self assert: (project outputDirectory / 'markdown' / 'index.markdown') exists
 ]
 
 { #category : #tests }

--- a/src/Pillar-Tests-Integration/PRIntegrationTest.class.st
+++ b/src/Pillar-Tests-Integration/PRIntegrationTest.class.st
@@ -53,6 +53,12 @@ PRIntegrationTest >> outputHtml [
 ]
 
 { #category : #parameters }
+PRIntegrationTest >> outputMarkdown [
+
+	^ PRMarkdownOutput new
+]
+
+{ #category : #parameters }
 PRIntegrationTest >> outputPdf [
 
 	^ PRPdfOutput new
@@ -140,6 +146,13 @@ PRIntegrationTest >> testPresentationHtml [
 ]
 
 { #category : #tests }
+PRIntegrationTest >> testPresentationMarkdown [
+
+	self testArchetype: self archetypePresentation output: self outputMarkdown.
+	self assert: (project outputDirectory / 'markdown' / 'index.markdown') exists.
+]
+
+{ #category : #tests }
 PRIntegrationTest >> testPresentationPdf [
 
 	self timeLimit: 2 minutes.
@@ -152,6 +165,13 @@ PRIntegrationTest >> testWelcomeHtml [
 
 	self testArchetype: self archetypeWelcome output: self outputHtml.
 	self assert: (project outputDirectory / 'html' / 'index.html') exists.
+]
+
+{ #category : #tests }
+PRIntegrationTest >> testWelcomeMarkdown [
+
+	self testArchetype: self archetypeWelcome output: self outputMarkdown.
+	self assert: (project outputDirectory / 'markdown' / 'index.markdown') exists.
 ]
 
 { #category : #tests }

--- a/src/Pillar-Tests-Integration/PRIntegrationTest.class.st
+++ b/src/Pillar-Tests-Integration/PRIntegrationTest.class.st
@@ -41,6 +41,12 @@ PRIntegrationTest >> ensureTestDirectory [
 ]
 
 { #category : #parameters }
+PRIntegrationTest >> outputAscii [
+
+	^ PRAsciiOutput new
+]
+
+{ #category : #parameters }
 PRIntegrationTest >> outputEPub [
 
 	^ PREPubOutput new
@@ -106,6 +112,13 @@ PRIntegrationTest >> testBasicLatexPdf [
 ]
 
 { #category : #tests }
+PRIntegrationTest >> testBookAscii [
+
+	self testArchetype: self archetypeBook output: self outputAscii.
+	self assert: (project outputDirectory / 'ascii' / 'index.ascii') exists.
+]
+
+{ #category : #tests }
 PRIntegrationTest >> testBookEpub [
 
 	| archive |
@@ -139,6 +152,13 @@ PRIntegrationTest >> testBookPdf [
 ]
 
 { #category : #tests }
+PRIntegrationTest >> testPresentationAscii [
+
+	self testArchetype: self archetypePresentation output: self outputAscii.
+	self assert: (project outputDirectory / 'ascii' / 'index.ascii') exists.
+]
+
+{ #category : #tests }
 PRIntegrationTest >> testPresentationHtml [
 
 	self testArchetype: self archetypePresentation output: self outputHtml.
@@ -158,6 +178,13 @@ PRIntegrationTest >> testPresentationPdf [
 	self timeLimit: 2 minutes.
 	self testArchetype: self archetypePresentation output: self outputPdf.
 	self assert: (project outputDirectory / 'pdf' / 'index.pdf') exists.
+]
+
+{ #category : #tests }
+PRIntegrationTest >> testWelcomeAscii [
+
+	self testArchetype: self archetypeWelcome output: self outputAscii.
+	self assert: (project outputDirectory / 'ascii' / 'index.ascii') exists.
 ]
 
 { #category : #tests }

--- a/src/Pillar-Tests-Integration/PRIntegrationTest.class.st
+++ b/src/Pillar-Tests-Integration/PRIntegrationTest.class.st
@@ -144,6 +144,13 @@ PRIntegrationTest >> testBookHtml [
 ]
 
 { #category : #tests }
+PRIntegrationTest >> testBookMarkdown [
+
+	self testArchetype: self archetypeBook output: self outputMarkdown.
+	self assert: (project outputDirectory / 'markdown' / 'index.markdown') exists.
+]
+
+{ #category : #tests }
 PRIntegrationTest >> testBookPdf [
 
 	self timeLimit: 2 minutes.

--- a/src/Pillar-Tests-Project/ProjectDefaultTargetTest.class.st
+++ b/src/Pillar-Tests-Project/ProjectDefaultTargetTest.class.st
@@ -22,6 +22,21 @@ ProjectDefaultTargetTest >> configAbsentTargetContent [
 ]
 
 { #category : #tests }
+ProjectDefaultTargetTest >> configAsciiContent [
+	^ '{
+  "base_url": "",
+  "site_name": "Pharo Book",
+  "title": "The Pillar Super Book Archetype",
+  "attribution": "The Pillar team",
+  "series": "Square Bracket tutorials",
+  "keywords": "project template, Pillar, Pharo, Smalltalk",
+  "language": "en-UK",
+  "latexWriter" : #latex,
+  "defaultExport" : "ascii"
+}'
+]
+
+{ #category : #tests }
 ProjectDefaultTargetTest >> configHTMLContent [
 	^ '{
   "base_url": "",
@@ -52,6 +67,21 @@ ProjectDefaultTargetTest >> configInvalidTargetContent [
 ]
 
 { #category : #tests }
+ProjectDefaultTargetTest >> configMarkdownContent [
+	^ '{
+  "base_url": "",
+  "site_name": "Pharo Book",
+  "title": "The Pillar Super Book Archetype",
+  "attribution": "The Pillar team",
+  "series": "Square Bracket tutorials",
+  "keywords": "project template, Pillar, Pharo, Smalltalk",
+  "language": "en-UK",
+  "latexWriter" : #latex,
+  "defaultExport" : "markdown"
+}'
+]
+
+{ #category : #tests }
 ProjectDefaultTargetTest >> configPDFContent [
 	^ '{
   "base_url": "",
@@ -78,6 +108,17 @@ ProjectDefaultTargetTest >> testDefaultTargetAbsent [
 ]
 
 { #category : #tests }
+ProjectDefaultTargetTest >> testDefaultTargetAscii [
+	| directory |
+	directory := FileSystem memory root.
+	directory / 'pillar.conf'
+		writeStreamDo: [ :st | st nextPutAll: self configAsciiContent ].
+	project := PRProject new baseDirectory: directory.
+	
+	self assert: project defaultTarget equals: PRAsciiOutput
+]
+
+{ #category : #tests }
 ProjectDefaultTargetTest >> testDefaultTargetHTML [
 	| directory |
 	directory := FileSystem memory root.
@@ -97,6 +138,17 @@ ProjectDefaultTargetTest >> testDefaultTargetInvalid [
 	project := PRProject new baseDirectory: directory.
 	
 	self assert: project defaultTarget equals: PRInvalidTarget
+]
+
+{ #category : #tests }
+ProjectDefaultTargetTest >> testDefaultTargetMarkdown [
+	| directory |
+	directory := FileSystem memory root.
+	directory / 'pillar.conf'
+		writeStreamDo: [ :st | st nextPutAll: self configMarkdownContent ].
+	project := PRProject new baseDirectory: directory.
+	
+	self assert: project defaultTarget equals: PRMarkdownOutput
 ]
 
 { #category : #tests }


### PR DESCRIPTION
For both "ascii" and "markdown":
- a PRWritingTarget
- a PROutputDocument
- tests: PRIntegrationTest and ProjectDefaultTargetTest