### PR TITLE
BookTester process for CLAP

### DIFF
--- a/src/Pillar-BookTester/PRCheckBookDocument.class.st
+++ b/src/Pillar-BookTester/PRCheckBookDocument.class.st
@@ -8,15 +8,31 @@ Class {
 	#category : #'Pillar-BookTester-CommandLine'
 }
 
+{ #category : #writing }
+PRCheckBookDocument >> basicWriter [
+	" No basicWriter : do nothing"
+]
+
 { #category : #building }
 PRCheckBookDocument >> buildOn: aPRProject [ 
 	
-	| parsedDocument transformedDocument bTester stream |
+	| parsedDocument transformedDocument |
 	parsedDocument := self parseInputFile: file.
 	transformedDocument := self transformDocument: parsedDocument.
+	^ self writeDocument: transformedDocument.
+]
+
+{ #category : #building }
+PRCheckBookDocument >> extension [
+	^ 'txt'
+]
+
+{ #category : #building }
+PRCheckBookDocument >> writeDocument: aDocument [
+	| bTester checkReport outputFile| 
 	bTester := PRBookTesterVisitor new.
-	bTester start: transformedDocument.
-	stream := String streamContents: 
+	bTester start: aDocument.
+	checkReport := String streamContents: 
 				 [ :s |
 					s << file fullName.
 					s crlf.
@@ -31,8 +47,12 @@ PRCheckBookDocument >> buildOn: aPRProject [
 											  		 	s crlf; crlf. ].
 				   s << 'File Checked!'.
 					s crlf;crlf.].
-	Stdio stdout 
-		nextPutAll: stream contents.
+	outputFile := (self outputDirectory resolve: (file file asAbsolute relativeTo: project baseDirectory asAbsolute)) withoutExtension , self extension.
+	outputFile ensureDelete.
+	outputFile parent ensureCreateDirectory.
+	outputFile writeStreamDo: [ :stream | stream nextPutAll: checkReport contents].
+	
 	bTester allTestResults do: [:each | bTester finalStatus: (bTester finalStatus and: each status) ].	
 	^ PRStatus withStatus: bTester finalStatus
+	
 ]

--- a/src/Pillar-BookTester/PRCheckBookTarget.class.st
+++ b/src/Pillar-BookTester/PRCheckBookTarget.class.st
@@ -14,12 +14,24 @@ PRCheckBookTarget class >> builderName [
 ]
 
 { #category : #building }
+PRCheckBookTarget >> buildOn: aProject [
+	| status |
+	status := PRSuccess new.
+	
+	"We chech each file"
+	(self filesToBuildOn: aProject) do: [ :each |
+		status := status and: ((self documentFor: each) buildOn: aProject) ].
+
+	^ status
+]
+
+{ #category : #building }
 PRCheckBookTarget >> documentFor: aFile [
 	^ PRCheckBookDocument new
 		project: aFile project;
 		file: aFile;
 		target: self;
-		outputDirectory: aFile project outputDirectory / self outputDirectoryName ;
+		outputDirectory: (aFile project baseDirectory / self outputDirectoryName ) ensureCreateDirectory;
 		yourself
 ]
 
@@ -30,7 +42,7 @@ PRCheckBookTarget >> extension [
 
 { #category : #accessing }
 PRCheckBookTarget >> outputDirectoryName [ 
-	^ 'check_report'
+	^ '_check'
 ]
 
 { #category : #preparation }

--- a/src/Pillar-BookTester/PRCheckBookTarget.class.st
+++ b/src/Pillar-BookTester/PRCheckBookTarget.class.st
@@ -4,7 +4,7 @@ Looks like a little hack to be able to pass extra parameters during the document
 Class {
 	#name : #PRCheckBookTarget,
 	#superclass : #PRTarget,
-	#category : 'Pillar-BookTester-CommandLine'
+	#category : #'Pillar-BookTester-CommandLine'
 }
 
 { #category : #accessing }
@@ -15,12 +15,22 @@ PRCheckBookTarget class >> builderName [
 
 { #category : #building }
 PRCheckBookTarget >> documentFor: aFile [
-
 	^ PRCheckBookDocument new
 		project: aFile project;
 		file: aFile;
 		target: self;
+		outputDirectory: aFile project outputDirectory / self outputDirectoryName ;
 		yourself
+]
+
+{ #category : #accessing }
+PRCheckBookTarget >> extension [
+	^ 'txt'
+]
+
+{ #category : #accessing }
+PRCheckBookTarget >> outputDirectoryName [ 
+	^ 'check_report'
 ]
 
 { #category : #preparation }

--- a/src/Pillar-Cli/ClapPillarCheckCommand.class.st
+++ b/src/Pillar-Cli/ClapPillarCheckCommand.class.st
@@ -1,0 +1,39 @@
+Class {
+	#name : #ClapPillarCheckCommand,
+	#superclass : #ClapPillarCommand,
+	#category : #'Pillar-Cli-Clap'
+}
+
+{ #category : #accessing }
+ClapPillarCheckCommand class >> commandName [
+	^ 'check'
+]
+
+{ #category : #'command line' }
+ClapPillarCheckCommand class >> commandSpecification [
+	<commandline>
+	^ (ClapCommand id: self commandName asSymbol)
+		description: 'Check code in all the codeblocks in given file or book, then generate a report';
+		add: ClapFlag forHelp;
+		add: ((ClapPositional id: #fileToCheck )
+			description: 'Pillar document you want to check';
+			implicitMeaning: [ '' ]);
+		meaning:
+			[ :args |
+			args at: #helpFlag ifPresent: [ :help | help value; exitSuccess ].
+			(self with: args) execute ]
+	
+]
+
+{ #category : #execution }
+ClapPillarCheckCommand >> execute [
+	| target |
+	target := PRCheckBookTarget new.
+	target buildStrategy: (PRBuildListStrategy list: (self fileToCheck) asArray).
+	^ target buildOn: self project.
+]
+
+{ #category : #activation }
+ClapPillarCheckCommand >> fileToCheck [
+	^ (arguments at: #fileToCheck) value: self
+]

--- a/src/Pillar-Cli/ClapPillarCheckCommand.class.st
+++ b/src/Pillar-Cli/ClapPillarCheckCommand.class.st
@@ -30,7 +30,7 @@ ClapPillarCheckCommand class >> commandSpecification [
 				ifFalse: [ 
 					target buildStrategy: (PRBuildAllStrategy new)
 					 ].
-			^ target buildOn: self new project.
+			target buildOn: self new project.
 			]
 	
 ]

--- a/src/Pillar-Cli/ClapPillarCheckCommand.class.st
+++ b/src/Pillar-Cli/ClapPillarCheckCommand.class.st
@@ -12,28 +12,25 @@ ClapPillarCheckCommand class >> commandName [
 { #category : #'command line' }
 ClapPillarCheckCommand class >> commandSpecification [
 	<commandline>
+	| target |
+	target := PRCheckBookTarget new.
 	^ (ClapCommand id: self commandName asSymbol)
 		description: 'Check code in all the codeblocks in given file or book, then generate a report';
 		add: ClapFlag forHelp;
-		add: ((ClapPositional id: #fileToCheck )
-			description: 'Pillar document you want to check';
+		add: ((ClapPositional id: #requestedFiles )
+			description: 'Pillar document(s) you want to check';
 			implicitMeaning: [ '' ]);
 		meaning:
 			[ :args |
 			args at: #helpFlag ifPresent: [ :help | help value; exitSuccess ].
-			(self with: args) execute ]
+			(args at: #requestedFiles ) isExplicit 
+				ifTrue:[ 
+					target buildStrategy: (PRBuildListStrategy list: (args occurrencesOf: #requestedFiles collect: #value) )
+					]
+				ifFalse: [ 
+					target buildStrategy: (PRBuildAllStrategy new)
+					 ].
+			^ target buildOn: self new project.
+			]
 	
-]
-
-{ #category : #execution }
-ClapPillarCheckCommand >> execute [
-	| target |
-	target := PRCheckBookTarget new.
-	target buildStrategy: (PRBuildListStrategy list: (self fileToCheck) asArray).
-	^ target buildOn: self project.
-]
-
-{ #category : #activation }
-ClapPillarCheckCommand >> fileToCheck [
-	^ (arguments at: #fileToCheck) value: self
 ]

--- a/src/Pillar-Cli/ClapPillarServeCommand.class.st
+++ b/src/Pillar-Cli/ClapPillarServeCommand.class.st
@@ -35,7 +35,7 @@ ClapPillarServeCommand class >> commandSpecification [
 	
 ]
 
-{ #category : #accessing }
+{ #category : #activation }
 ClapPillarServeCommand >> baseurl [
 	^ baseurl ifNil: [ baseurl := (arguments at: #baseurl) value]
 ]
@@ -63,12 +63,12 @@ ClapPillarServeCommand >> execute [
 	^ self watch.
 ]
 
-{ #category : #accessing }
+{ #category : #activation }
 ClapPillarServeCommand >> port [
 	^ port ifNil: [ port := (arguments at: #port) value]
 ]
 
-{ #category : #running }
+{ #category : #activation }
 ClapPillarServeCommand >> watch [
 	(arguments at: #watch) isExplicit
 		ifFalse: [ ^ self ]

--- a/src/Pillar-ExporterCore/PRAbsentTarget.class.st
+++ b/src/Pillar-ExporterCore/PRAbsentTarget.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #PRAbsentTarget,
 	#superclass : #PRErrorTarget,
-	#category : #'Pillar-BookTester-CommandLine'
+	#category : #'Pillar-ExporterCore-Base'
 }
 
 { #category : #clap }

--- a/src/Pillar-ExporterCore/PRInvalidTarget.class.st
+++ b/src/Pillar-ExporterCore/PRInvalidTarget.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #PRInvalidTarget,
 	#superclass : #PRErrorTarget,
-	#category : #'Pillar-BookTester-CommandLine'
+	#category : #'Pillar-ExporterCore-Base'
 }
 
 { #category : #clap }


### PR DESCRIPTION
CLAP command for checking code in Pillar documents: 
- `clap pillar check` to check all Pillar files in directory
- `clap pillar check file1.pillar file2.pillar` to check a list of Pillar files

You'll get a directory `_check` with generated reports.

**TODO**
[ ] print a message in terminal to inform the end of process + success or fail
[ ] add comments
[ ] add tests
[ ] change report name ?? (with a suffix to differentiate from the original file)