### PR TITLE
Fix baseline pillarcore

### DIFF
--- a/src/BaselineOfPillarCore/BaselineOfPillarCore.class.st
+++ b/src/BaselineOfPillarCore/BaselineOfPillarCore.class.st
@@ -18,9 +18,9 @@ BaselineOfPillarCore >> baseline: spec [
 				package: 'Pillar-Tests-Core' with: [ spec 
 					requires: #( 'Pillar-Core' ) ];
 				package: 'Pillar-Tests-Model' with: [ spec 
-					requires: #( 'Pillar-Tests-Core' ) ].
+					requires: #( 'Pillar-Tests-Core' 'Pillar-Model') ].
 		spec
-			group: 'default' with: #('tests')	;
+			group: 'default' with: #('model' 'tests')	;
 			group: 'core' with: #('Pillar-Core');
 			group: 'model' with: #('Pillar-Model');
 			group: 'tests' with: #('Pillar-Tests-Core' 'Pillar-Tests-Model')					

--- a/src/BaselineOfPillarCore/BaselineOfPillarCore.class.st
+++ b/src/BaselineOfPillarCore/BaselineOfPillarCore.class.st
@@ -12,19 +12,18 @@ BaselineOfPillarCore >> baseline: spec [
 		for: #common
 		do: [ spec blessing: #baseline.
 			spec 
-				baseline: 'ContainersPropertyEnvironment' with: [ spec 
-					repository: 'github://Ducasse/Containers-PropertyEnvironment' ];
-				baseline: 'PetitParser2Core' with: [ spec
-					 repository: 'github://kursjan/petitparser2' ];
 				package: 'Pillar-Core';
-				package: 'Pillar-Model';
-				package: 'Pillar-PetitPillar' with: [ spec 
-					requires: #( 'PetitParser2Core' 'Pillar-Model' ) ];
-				"package: 'Pillar-Tests-Model' with: [ spec 
-					requires: #('Pillar-Model' 'Pillar-ExporterPilar' 'Pillar-ExporterText') ];"
-				package: 'Pillar-Tests-PetitPillar' with: [ spec 
-					requires: #( 'Pillar-PetitPillar' )  ]
-					
+				package: 'Pillar-Model' with: [ spec 
+					requires: #( 'Pillar-Core' ) ];
+				package: 'Pillar-Tests-Core' with: [ spec 
+					requires: #( 'Pillar-Core' ) ];
+				package: 'Pillar-Tests-Model' with: [ spec 
+					requires: #( 'Pillar-Tests-Core' ) ].
+		spec
+			group: 'default' with: #('tests')	;
+			group: 'core' with: #('Pillar-Core');
+			group: 'model' with: #('Pillar-Model');
+			group: 'tests' with: #('Pillar-Tests-Core' 'Pillar-Tests-Model')					
 	]
 
 ]

--- a/src/BaselineOfPillarFormat/BaselineOfPillarFormat.class.st
+++ b/src/BaselineOfPillarFormat/BaselineOfPillarFormat.class.st
@@ -29,9 +29,10 @@ BaselineOfPillarFormat >> baseline: spec [
 				package: 'Pillar-Microdown' with: [ 
 					spec requires: #('PillarCore' 'Microdown') ];
 				package: 'Pillar-ExporterMicrodown' with: [ 
-					spec requires: #('PillarCore' 'Microdown') ]";
-				package: 'Pillar-Tests-ExporterMicrodown' with: [ 
-					spec requires: #('PillarCore' 'Microdown') ]".
+					spec requires: #('PillarCore' 'Microdown') ];
+				"# rich text"
+				package: 'Pillar-ExporterRichText' with: [ 
+					spec requires: #('PillarCore' "pillar pear?") ].
 		spec 
 			group: 'default' with: #('pillar');
 			"# pillar "
@@ -40,12 +41,17 @@ BaselineOfPillarFormat >> baseline: spec [
 			group: 'pillar-parser-tests' with: #('Pillar-Tests-PetitPillar');
 			group: 'pillar-exporter' with: #('Pillar-ExporterPillar');
 			group: 'pillar-exporter-tests' with: #('Pillar-Tests-ExporterPillar');
+			
 			"# microdown"
 			group: 'microdown' with: #('microdown-parser' "'microdown-parser-tests'" 'microdown-exporter' "'microdown-exporter-tests'");
 			group: 'microdown-parser' with: #('Pillar-Microdown');
 			"group: 'pillar-parser-tests' with: #('Pillar-Tests-PetitPillar');"
 			group: 'microdown-exporter' with: #('Pillar-ExporterMicrodown')";
-			group: 'microdown-exporter-tests' with: #('Pillar-Tests-ExporterMicrodown')".
+			group: 'microdown-exporter-tests' with: #('Pillar-Tests-ExporterMicrodown')";
+			
+			"# rich text"
+			group: 'richtext' with: #('richtext-exporter');
+			group: 'richtext-exporter' with: #('Pillar-ExporterRichText').
 		
 		self 
 			pillarCore: spec;

--- a/src/BaselineOfPillarFormat/BaselineOfPillarFormat.class.st
+++ b/src/BaselineOfPillarFormat/BaselineOfPillarFormat.class.st
@@ -15,11 +15,17 @@ BaselineOfPillarFormat >> baseline: spec [
 				package: 'Pillar-PetitPillar' with: [ 
 					spec requires: #( 'PetitParser2Core' 'PillarCore' ) ];
 				package: 'Pillar-Tests-PetitPillar' with: [ 
-					spec requires: #( 'Pillar-PetitPillar' )  ].
+					spec requires: #( 'Pillar-PetitPillar' ) ].
+		spec 
+			group: 'default' with: #('pillar');
+			group: 'pillar' with: #('pillar-parser' 'pillar-parser-tests');
+			group: 'pillar-parser' with: #('Pillar-PetitPillar');
+			group: 'pillar-parser-tests' with: #('Pillar-Tests-PetitPillar').
+		
 		self 
-				pillarCore: spec;
-				containerPropertyEnvironment: spec;
-				petitParser2Core: spec ]
+			pillarCore: spec;
+			containerPropertyEnvironment: spec;
+			petitParser2Core: spec ]
 
 ]
 

--- a/src/BaselineOfPillarFormat/BaselineOfPillarFormat.class.st
+++ b/src/BaselineOfPillarFormat/BaselineOfPillarFormat.class.st
@@ -18,6 +18,8 @@ BaselineOfPillarFormat >> baseline: spec [
 					spec requires: #( 'Pillar-PetitPillar' ) ];
 				package: 'Pillar-ExporterCore' with: [ 
 					spec requires: #('PillarCore' 'ContainersPropertyEnvironment') ];
+				package: 'Pillar-Tests-ExporterCore' with: [ 
+					spec requires: #('Pillar-ExporterCore') ];
 				package: 'Pillar-ExporterPillar' with: [ 
 					spec requires: #('Pillar-ExporterCore' 'Pillar-PetitPillar') ];
 				package: 'Pillar-Tests-ExporterPillar' with: [ 

--- a/src/BaselineOfPillarFormat/BaselineOfPillarFormat.class.st
+++ b/src/BaselineOfPillarFormat/BaselineOfPillarFormat.class.st
@@ -15,12 +15,20 @@ BaselineOfPillarFormat >> baseline: spec [
 				package: 'Pillar-PetitPillar' with: [ 
 					spec requires: #( 'PetitParser2Core' 'PillarCore' ) ];
 				package: 'Pillar-Tests-PetitPillar' with: [ 
-					spec requires: #( 'Pillar-PetitPillar' ) ].
+					spec requires: #( 'Pillar-PetitPillar' ) ];
+				package: 'Pillar-ExporterCore' with: [ 
+					spec requires: #('PillarCore' 'ContainersPropertyEnvironment') ];
+				package: 'Pillar-ExporterPillar' with: [ 
+					spec requires: #('Pillar-ExporterCore' 'Pillar-PetitPillar') ];
+				package: 'Pillar-Tests-ExporterPillar' with: [ 
+					spec requires: #('Pillar-ExporterPillar' 'Pillar-Tests-ExporterCore') ].
 		spec 
 			group: 'default' with: #('pillar');
-			group: 'pillar' with: #('pillar-parser' 'pillar-parser-tests');
+			group: 'pillar' with: #('pillar-parser' 'pillar-parser-tests' 'pillar-exporter' 'pillar-exporter-tests');
 			group: 'pillar-parser' with: #('Pillar-PetitPillar');
-			group: 'pillar-parser-tests' with: #('Pillar-Tests-PetitPillar').
+			group: 'pillar-parser-tests' with: #('Pillar-Tests-PetitPillar');
+			group: 'pillar-exporter' with: #('Pillar-ExporterPillar');
+			group: 'pillar-exporter-tests' with: #('Pillar-Tests-ExporterPillar').
 		
 		self 
 			pillarCore: spec;

--- a/src/BaselineOfPillarFormat/BaselineOfPillarFormat.class.st
+++ b/src/BaselineOfPillarFormat/BaselineOfPillarFormat.class.st
@@ -1,0 +1,48 @@
+Class {
+	#name : #BaselineOfPillarFormat,
+	#superclass : #BaselineOf,
+	#category : #BaselineOfPillarFormat
+}
+
+{ #category : #baselines }
+BaselineOfPillarFormat >> baseline: spec [
+	<baseline>
+
+	spec
+		for: #common
+		do: [
+			spec 
+				package: 'Pillar-PetitPillar' with: [ 
+					spec requires: #( 'PetitParser2Core' 'PillarCore' ) ];
+				package: 'Pillar-Tests-PetitPillar' with: [ 
+					spec requires: #( 'Pillar-PetitPillar' )  ].
+		self 
+				pillarCore: spec;
+				containerPropertyEnvironment: spec;
+				petitParser2Core: spec ]
+
+]
+
+{ #category : #baselines }
+BaselineOfPillarFormat >> containerPropertyEnvironment: spec [ 
+	spec 
+		baseline: 'ContainersPropertyEnvironment' with: [ 
+			spec 
+				repository: 'github://Ducasse/Containers-PropertyEnvironment' ]
+]
+
+{ #category : #baselines }
+BaselineOfPillarFormat >> petitParser2Core: spec [ 
+	spec 
+		baseline: 'PetitParser2Core' with: [ 
+			spec
+				repository: 'github://kursjan/petitparser2' ]
+]
+
+{ #category : #baselines }
+BaselineOfPillarFormat >> pillarCore: spec [ 
+	spec 
+		baseline: 'PillarCore' with: [ 
+			spec
+				repository: 'github://pillar-markup/pillar' ]
+]

--- a/src/BaselineOfPillarFormat/BaselineOfPillarFormat.class.st
+++ b/src/BaselineOfPillarFormat/BaselineOfPillarFormat.class.st
@@ -12,6 +12,7 @@ BaselineOfPillarFormat >> baseline: spec [
 		for: #common
 		do: [
 			spec 
+				"# pillar"
 				package: 'Pillar-PetitPillar' with: [ 
 					spec requires: #( 'PetitParser2Core' 'PillarCore' ) ];
 				package: 'Pillar-Tests-PetitPillar' with: [ 
@@ -23,20 +24,31 @@ BaselineOfPillarFormat >> baseline: spec [
 				package: 'Pillar-ExporterPillar' with: [ 
 					spec requires: #('Pillar-ExporterCore' 'Pillar-PetitPillar') ];
 				package: 'Pillar-Tests-ExporterPillar' with: [ 
-					spec requires: #('Pillar-ExporterPillar' 'Pillar-Tests-ExporterCore') ].
+					spec requires: #('Pillar-ExporterPillar' 'Pillar-Tests-ExporterCore') ];
+				"# microdown"
+				package: 'Pillar-Microdown' with: [ 
+					spec requires: #('PillarCore' 'Microdown') ];
+				package: 'Pillar-ExporterMicrodown' with: [ 
+					spec requires: #('PillarCore' 'Microdown') ].
 		spec 
 			group: 'default' with: #('pillar');
+			"# pillar "
 			group: 'pillar' with: #('pillar-parser' 'pillar-parser-tests' 'pillar-exporter' 'pillar-exporter-tests');
 			group: 'pillar-parser' with: #('Pillar-PetitPillar');
 			group: 'pillar-parser-tests' with: #('Pillar-Tests-PetitPillar');
 			group: 'pillar-exporter' with: #('Pillar-ExporterPillar');
-			group: 'pillar-exporter-tests' with: #('Pillar-Tests-ExporterPillar').
+			group: 'pillar-exporter-tests' with: #('Pillar-Tests-ExporterPillar');
+			"# microdown"
+			group: 'microdown' with: #('microdown-parser' 'microdown-parser-tests' 'microdown-exporter' 'microdown-exporter-tests');
+			group: 'microdown-parser' with: #('Pillar-Microdown');
+			"group: 'pillar-parser-tests' with: #('Pillar-Tests-PetitPillar');"
+			group: 'microdown-exporter' with: #('Pillar-ExporterMicrodown');
+			group: 'microdown-exporter-tests' with: #('Pillar-Tests-ExporterMicrodown').
 		
 		self 
 			pillarCore: spec;
 			containerPropertyEnvironment: spec;
 			petitParser2Core: spec ]
-
 ]
 
 { #category : #baselines }
@@ -45,6 +57,14 @@ BaselineOfPillarFormat >> containerPropertyEnvironment: spec [
 		baseline: 'ContainersPropertyEnvironment' with: [ 
 			spec 
 				repository: 'github://Ducasse/Containers-PropertyEnvironment' ]
+]
+
+{ #category : #baselines }
+BaselineOfPillarFormat >> microdown: spec [ 
+	spec 
+		baseline: 'Microdown' with: [ 
+			spec
+				repository: 'github://pillar-markup/Micordown/src' ]
 ]
 
 { #category : #baselines }

--- a/src/BaselineOfPillarFormat/BaselineOfPillarFormat.class.st
+++ b/src/BaselineOfPillarFormat/BaselineOfPillarFormat.class.st
@@ -12,7 +12,7 @@ BaselineOfPillarFormat >> baseline: spec [
 		for: #common
 		do: [
 			spec 
-				"# pillar"
+				"# pillar" 
 				package: 'Pillar-PetitPillar' with: [ 
 					spec requires: #( 'PetitParser2Core' 'PillarCore' ) ];
 				package: 'Pillar-Tests-PetitPillar' with: [ 
@@ -29,7 +29,9 @@ BaselineOfPillarFormat >> baseline: spec [
 				package: 'Pillar-Microdown' with: [ 
 					spec requires: #('PillarCore' 'Microdown') ];
 				package: 'Pillar-ExporterMicrodown' with: [ 
-					spec requires: #('PillarCore' 'Microdown') ].
+					spec requires: #('PillarCore' 'Microdown') ]";
+				package: 'Pillar-Tests-ExporterMicrodown' with: [ 
+					spec requires: #('PillarCore' 'Microdown') ]".
 		spec 
 			group: 'default' with: #('pillar');
 			"# pillar "
@@ -39,14 +41,15 @@ BaselineOfPillarFormat >> baseline: spec [
 			group: 'pillar-exporter' with: #('Pillar-ExporterPillar');
 			group: 'pillar-exporter-tests' with: #('Pillar-Tests-ExporterPillar');
 			"# microdown"
-			group: 'microdown' with: #('microdown-parser' 'microdown-parser-tests' 'microdown-exporter' 'microdown-exporter-tests');
+			group: 'microdown' with: #('microdown-parser' "'microdown-parser-tests'" 'microdown-exporter' "'microdown-exporter-tests'");
 			group: 'microdown-parser' with: #('Pillar-Microdown');
 			"group: 'pillar-parser-tests' with: #('Pillar-Tests-PetitPillar');"
-			group: 'microdown-exporter' with: #('Pillar-ExporterMicrodown');
-			group: 'microdown-exporter-tests' with: #('Pillar-Tests-ExporterMicrodown').
+			group: 'microdown-exporter' with: #('Pillar-ExporterMicrodown')";
+			group: 'microdown-exporter-tests' with: #('Pillar-Tests-ExporterMicrodown')".
 		
 		self 
 			pillarCore: spec;
+			microdown: spec;
 			containerPropertyEnvironment: spec;
 			petitParser2Core: spec ]
 ]
@@ -64,7 +67,7 @@ BaselineOfPillarFormat >> microdown: spec [
 	spec 
 		baseline: 'Microdown' with: [ 
 			spec
-				repository: 'github://pillar-markup/Micordown/src' ]
+				repository: 'github://pillar-markup/MicroDown/src' ]
 ]
 
 { #category : #baselines }

--- a/src/BaselineOfPillarFormat/package.st
+++ b/src/BaselineOfPillarFormat/package.st
@@ -1,0 +1,1 @@
+Package { #name : #BaselineOfPillarFormat }


### PR DESCRIPTION
This baseline is clean, has all necessary dependencies and groups so loading should be working. Now we have tests failing. That needs to be fixed later because the assumption about the presence of the pillar markup has gone