### PR TITLE
Update the checkout branch to the last release (README)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ For SSH setup, execute the `build.sh` script found in the `scripts` directory:
 ```bash
 $ git clone git@github.com:pillar-markup/pillar.git
 $ cd pillar
-$ git checkout v8.0.12
+$ git checkout v8.0.14
 $ chmod a+x ./scripts/build.sh
 $ ./scripts/build.sh
 ```

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ For HTTPS setup, execute the `build.sh` script found in the `scripts` directory:
 ```bash
 $ git clone https://github.com/pillar-markup/pillar.git
 $ cd pillar
-$ git checkout v8.0.12
+$ git checkout v8.0.14
 $ chmod a+x ./scripts/build.sh
 $ ./scripts/build.sh
 ```
@@ -48,7 +48,7 @@ LICENSE  README.md  appveyor.yml  archetypes  ==>>build<<==  download.sh  script
 
 #### Current version
 
-- Current version is Pillar v8.0.12
+- Current version is Pillar v8.0.14
 - Most Pharo booklets are using v7.7.4 and are under migration to v8.0.12
 
 
@@ -176,7 +176,8 @@ Read the documentation at [https://github.com/SquareBracketAssociates/Booklet-Pu
 Please note that chapter on "Pharo a web Perspective" is obsolete since it refers to Pharo 60.
 
 ## History
-- 8.0.12 current stable version. Tagged versions from 8.0.4 to 8.0.12 excluded got broken due to a class renaming. 8.0.12 is now green tests and loads. It is the future candidate for stable.
+- 8.0.14 current stable version
+- 8.0.12 Tagged versions from 8.0.4 to 8.0.12 excluded got broken due to a class renaming. 8.0.12 is now green tests and loads. It is the future candidate for stable.
 - 7.7.4 Last version before moving to P8.
 - 7.7.3 introduces the possibility to use LaTeX 2018 or the rolling version of 2019. Check the ensure-deps.sh and companion travis file in the support/latex of the archetype.
 - 7.7.0 cleaned useless features, plus travis builds.


### PR DESCRIPTION
Update the README file to use the last release that is v8.0.14, not v8.0.12