### PR TITLE
- Refactoring for the writer computation to avoid hardcoding the subc…

### DIFF
--- a/src/Pillar-Core/PRDocument.class.st
+++ b/src/Pillar-Core/PRDocument.class.st
@@ -46,3 +46,11 @@ PRDocument >> next [
 PRDocument >> next: aDocument [
 	^ self propertyAt: 'next' put: aDocument
 ]
+
+{ #category : #'pillar integration' }
+PRDocument >> transformDocumentFor: aPRPDFDocument [
+	"This is a hook to be able to have framework specific transformation hooks.
+	see PRAbstractOutputDocument>>#buildOn:"
+	
+	^ aPRPDFDocument transformDocument: self
+]

--- a/src/Pillar-ExporterCore/PRAbstractOutputDocument.class.st
+++ b/src/Pillar-ExporterCore/PRAbstractOutputDocument.class.st
@@ -28,7 +28,7 @@ PRAbstractOutputDocument >> buildOn: aPRProject [
 	| parsedDocument transformedDocument writtenFile |
 	parsedDocument := self parseInputFile: file.
 	parsedDocument properties: (self metadataConfigurationForDocument: parsedDocument).
-	transformedDocument := self transformDocument: parsedDocument.
+	transformedDocument := parsedDocument transformDocumentFor: self.
 	writtenFile := self writeDocument: transformedDocument.
 	self postWriteTransform: writtenFile.
 	^ PRSuccess new.

--- a/src/Pillar-ExporterCore/PRBuildRootMainStrategy.class.st
+++ b/src/Pillar-ExporterCore/PRBuildRootMainStrategy.class.st
@@ -16,7 +16,7 @@ PRBuildRootMainStrategy >> filesToBuildOn: aProject [
 	
 	| pillarFiles|
 	pillarFiles := aProject baseDirectory children select: [ :each | each isFile and: [ self isSupportedExtension: each  extension ] ].
-	pillarFiles ifEmpty: [ self error: 'There is no pillar file in the repository root.' ].
+	pillarFiles ifEmpty: [ self error: 'There is no pillar (md or pillar) file in the repository root.' ].
 	pillarFiles size = 1 ifTrue: [ ^ { (PRInputDocument forFile: pillarFiles first) 
 			project: aProject;
 			yourself } ].

--- a/src/Pillar-ExporterCore/PRBuildStrategy.class.st
+++ b/src/Pillar-ExporterCore/PRBuildStrategy.class.st
@@ -21,7 +21,7 @@ PRBuildStrategy >> filesToBuildOn: aProject [
 PRBuildStrategy >> initialize [
 
 	super initialize.
-	supportedLanguageExtensions := #('pillar' 'mic')
+	supportedLanguageExtensions := #('pillar' 'mic' 'md' 'MIC' 'MD')
 ]
 
 { #category : #accessing }

--- a/src/Pillar-ExporterCore/PRInputDocument.class.st
+++ b/src/Pillar-ExporterCore/PRInputDocument.class.st
@@ -16,8 +16,20 @@ PRInputDocument class >> forFile: aFile [
 
 { #category : #factory }
 PRInputDocument class >> inputClassForFile: aFile [
+	"In the future classes should register explicitely and not be based on subclasses or implementator tricks."
 	
-	^ self subclasses
+	
+	"^ self subclasses
+		detect: [ :each | each doesHandleExtension: aFile extension ]
+		ifNone: [ PRNoInputDocument  ]
+		
+	before microdown integration we only looked in the subclasses of PRInputDocument. 
+	Now MicInputDocument is not a subclass of PRInputDocument for dependency reasons.
+	It could be fixed with proper packaging."
+	
+	
+	^ ((SystemNavigation default allImplementorsOf: #doesHandleExtension:) 
+		collect: [ :each | each methodClass instanceSide ]) 
 		detect: [ :each | each doesHandleExtension: aFile extension ]
 		ifNone: [ PRNoInputDocument  ]
 ]

--- a/src/Pillar-ExporterCore/PRWritingTarget.class.st
+++ b/src/Pillar-ExporterCore/PRWritingTarget.class.st
@@ -58,3 +58,17 @@ PRWritingTarget >> writerFor: aPRPillarConfiguration [
 	
 	self subclassResponsibility
 ]
+
+{ #category : #accessing }
+PRWritingTarget >> writerFor: aPRPillarConfiguration forConfigurationTag: aTag [
+	
+	"(PRDocumentWriter allSubclasses detect: [ :each | 
+		each isAbstract not
+			and: [ each writerName = (aPRPillarConfiguration propertyAt: #latexWriter) ] ])
+				new"
+				
+	^ (((SystemNavigation default allImplementorsOf: #writerName) 
+		collect: [ :each | each methodClass instanceSide ]) 
+			 detect: [ :each | 	each isAbstract not 
+						and: [ each writerName asLowercase = (aPRPillarConfiguration propertyAt: aTag) asLowercase ] ]) new
+]

--- a/src/Pillar-ExporterHTML/PRHtmlOutput.class.st
+++ b/src/Pillar-ExporterHTML/PRHtmlOutput.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #PRHtmlOutput,
 	#superclass : #PRWritingTarget,
-	#category : 'Pillar-ExporterHTML'
+	#category : #'Pillar-ExporterHTML'
 }
 
 { #category : #accessing }
@@ -36,8 +36,5 @@ PRHtmlOutput >> outputDirectoryName [
 { #category : #accessing }
 PRHtmlOutput >> writerFor: aPRPillarConfiguration [ 
 	
-	^ (PRDocumentWriter allSubclasses detect: [ :each | 
-		each isAbstract not
-			and: [ each writerName = (aPRPillarConfiguration propertyAt: #htmlWriter) ] ])
-				new
+	^ self writerFor: aPRPillarConfiguration forConfigurationTag: #htmlWriter
 ]

--- a/src/Pillar-ExporterLaTeX/PRPdfOutput.class.st
+++ b/src/Pillar-ExporterLaTeX/PRPdfOutput.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #PRPdfOutput,
 	#superclass : #PRWritingTarget,
-	#category : 'Pillar-ExporterLaTeX'
+	#category : #'Pillar-ExporterLaTeX'
 }
 
 { #category : #accessing }
@@ -36,8 +36,5 @@ PRPdfOutput >> outputDirectoryName [
 { #category : #accessing }
 PRPdfOutput >> writerFor: aPRPillarConfiguration [ 
 	
-	^ (PRDocumentWriter allSubclasses detect: [ :each | 
-		each isAbstract not
-			and: [ each writerName = (aPRPillarConfiguration propertyAt: #latexWriter) ] ])
-				new
+	^ self writerFor: aPRPillarConfiguration forConfigurationTag: #latexWriter
 ]


### PR DESCRIPTION
…lasses (because microdown infrastructure are not in the same hierarchy)

- Remove duplicated logic between HTML writer and latex writers
- make sure that the input file create microdown input files and not pillar ones
- Introduce the hook transformDocumentFor: to able to perform different transformations on mic or pillar. 
- Make sure that md files are considered as microdown.