### PR TITLE
Change the method fileToBuildOn: of PRBuildRootMainStrategy

### DIFF
--- a/src/Pillar-ExporterCore/PRBuildRootMainStrategy.class.st
+++ b/src/Pillar-ExporterCore/PRBuildRootMainStrategy.class.st
@@ -13,9 +13,10 @@ Class {
 { #category : #accessing }
 PRBuildRootMainStrategy >> filesToBuildOn: aProject [ 
 	"select the only file with pillar extension in current directory ; if there is no OR several pillar files, relative error is raised"
+	"Now it select a file named index which can be a pillar or a microdown file and if there is no one, relative error is raised"
 	
 	| pillarFiles|
-	pillarFiles := aProject baseDirectory children select: [ :each | each isFile and: [ self isSupportedExtension: each  extension ] ].
+	pillarFiles := aProject baseDirectory children select: [ :each | each isFile and: [ each base = 'index'  and: [ self isSupportedExtension: each  extension ]] ].
 	pillarFiles ifEmpty: [ self error: 'There is no pillar (md or pillar) file in the repository root.' ].
 	pillarFiles size = 1 ifTrue: [ ^ { (PRInputDocument forFile: pillarFiles first) 
 			project: aProject;


### PR DESCRIPTION
 for be able to build if we have a README or something else in microdown because now we build pillar and microdown file but it has to be named index