### PR TITLE
Fix visitCodeBlock: of PRMicrodownWriter to correctly convert the caption from Pillar to Microdown

### DIFF
--- a/src/Pillar-ExporterCore/PRBuildRootMainStrategy.class.st
+++ b/src/Pillar-ExporterCore/PRBuildRootMainStrategy.class.st
@@ -13,9 +13,10 @@ Class {
 { #category : #accessing }
 PRBuildRootMainStrategy >> filesToBuildOn: aProject [ 
 	"select the only file with pillar extension in current directory ; if there is no OR several pillar files, relative error is raised"
+	"Now it select a file named index which can be a pillar or a microdown file and if there is no one, relative error is raised"
 	
 	| pillarFiles|
-	pillarFiles := aProject baseDirectory children select: [ :each | each isFile and: [ self isSupportedExtension: each  extension ] ].
+	pillarFiles := aProject baseDirectory children select: [ :each | each isFile and: [ each base = 'index'  and: [ self isSupportedExtension: each  extension ]] ].
 	pillarFiles ifEmpty: [ self error: 'There is no pillar (md or pillar) file in the repository root.' ].
 	pillarFiles size = 1 ifTrue: [ ^ { (PRInputDocument forFile: pillarFiles first) 
 			project: aProject;

--- a/src/Pillar-ExporterCore/PRBuildRootMainStrategy.class.st
+++ b/src/Pillar-ExporterCore/PRBuildRootMainStrategy.class.st
@@ -16,7 +16,8 @@ PRBuildRootMainStrategy >> filesToBuildOn: aProject [
 	"Now it select a file named index which can be a pillar or a microdown file and if there is no one, relative error is raised"
 	
 	| pillarFiles|
-	pillarFiles := aProject baseDirectory children select: [ :each | each isFile and: [ each base = 'index'  and: [ self isSupportedExtension: each  extension ]] ].
+	pillarFiles := aProject baseDirectory children select: [ :each | each isFile and:[ self isSupportedExtension: each  extension ] ].
+	pillarFiles reject: [ :each | each basename = 'README' ].
 	pillarFiles ifEmpty: [ self error: 'There is no pillar (md or pillar) file in the repository root.' ].
 	pillarFiles size = 1 ifTrue: [ ^ { (PRInputDocument forFile: pillarFiles first) 
 			project: aProject;

--- a/src/Pillar-ExporterMicrodown/PRMicrodownWriter.class.st
+++ b/src/Pillar-ExporterMicrodown/PRMicrodownWriter.class.st
@@ -99,22 +99,17 @@ PRMicrodownWriter >> visitChildrenWithoutBackslash: aChildren [
 PRMicrodownWriter >> visitCodeblock: aCodeBlock [ 
 	
 	"the only parameter that could be contain a Pillar element is the caption so let us treat separately"
-	| microdownizedCaption associations caption isCaptionInParameters |
-	associations := aCodeBlock parameters associations.
+	| microdownizedCaption parameters caption |
+	parameters := aCodeBlock parameters .
 	"aCodeBlock hasCaption is not working well so use the accessor"
 	caption := aCodeBlock caption.
 	caption text isEmpty
 		ifFalse: [ microdownizedCaption := self class new start: caption; contents.
-					isCaptionInParameters := aCodeBlock parameters at: 'caption' ifAbsent: [ nil ].
-					isCaptionInParameters isNil not
-						ifTrue: [ associations := aCodeBlock parameters associations collect: [ :each |
-							each value = 'caption'
-								ifTrue: [ ('caption' -> microdownizedCaption) ]
-								ifFalse: [ each ]]] 
-						ifFalse: [ associations := aCodeBlock parameters associations ,  {('caption' -> microdownizedCaption)} ]].
+					parameters at: 'caption' put: microdownizedCaption].
 				
 	"may be we should change the builder to accept an orderedDictionary so that we can just change the caption."
-	canvas codeblock: aCodeBlock text firstLineAssociations: associations
+	canvas codeblock: aCodeBlock text firstLineAssociations: parameters associations.
+	
 ]
 
 { #category : #'visiting - slides' }


### PR DESCRIPTION
And also in the method FileToBuildOn: of PRBuildRootMainStrategy for not considering the README as a file to convert