### PR TITLE
Change done to math support in the conversion from Pillar to Microdown

### DIFF
--- a/src/Pillar-ExporterMicrodown/PRMicrodownWriter.class.st
+++ b/src/Pillar-ExporterMicrodown/PRMicrodownWriter.class.st
@@ -215,6 +215,14 @@ PRMicrodownWriter >> visitListItem: anObject [
 	^ self visitDocumentGroup: anObject
 ]
 
+{ #category : #'visiting - list' }
+PRMicrodownWriter >> visitMathInline: aMathLine [
+    | text |
+    text := aMathLine text.
+    text := text copyFrom: 2 to: (text size - 1). 
+    canvas mathInline: text
+]
+
 { #category : #'visiting - document' }
 PRMicrodownWriter >> visitMetadata: aMetaData [
 

--- a/src/Pillar-ExporterMicrodown/PRMicrodownWriter.class.st
+++ b/src/Pillar-ExporterMicrodown/PRMicrodownWriter.class.st
@@ -215,6 +215,12 @@ PRMicrodownWriter >> visitListItem: anObject [
 	^ self visitDocumentGroup: anObject
 ]
 
+{ #category : #'visiting-document' }
+PRMicrodownWriter >> visitMathEnvironment: aMathEnv [
+
+    canvas mathblock: aMathEnv text
+]
+
 { #category : #'visiting - list' }
 PRMicrodownWriter >> visitMathInline: aMathLine [
     | text |
@@ -270,6 +276,22 @@ PRMicrodownWriter >> visitPreformatted: aPreformatted [
 		aPreformatted children
 			do: [ :child | self visit: child ]
 			separatedBy: [ canvas newLine ] ]
+]
+
+{ #category : #'visiting-document' }
+PRMicrodownWriter >> visitRaw: aRaw [
+
+	| text |
+	text := aRaw text trimBoth.
+
+	((text beginsWith: '[') and: [ text endsWith: ']' ])
+		ifTrue: [ self visitMathEnvironment: aRaw ]
+		ifFalse: [ 
+			((text beginsWith: '$') and: [ text endsWith: '$' ])
+				ifTrue: [ self visitMathInline: aRaw ]
+				ifFalse: [ 
+					(aRaw isForType: self writerName) ifTrue: [ 
+						self writeRawDuring: [ super visitRaw: aRaw ] ] ] ]
 ]
 
 { #category : #'visiting - slides' }

--- a/src/Pillar-ExporterMicrodown/PRMicrodownWriter.class.st
+++ b/src/Pillar-ExporterMicrodown/PRMicrodownWriter.class.st
@@ -184,17 +184,24 @@ PRMicrodownWriter >> visitHorizontalRule: anHorizontalLine [
 
 { #category : #visiting }
 PRMicrodownWriter >> visitInputFileAnnotation: anInput [
+    | newParameters |
 
-	canvas raw: '<? inputFile: '.
-	anInput parameters ifNotEmpty: [ canvas raw: '|' ].
-	anInput parameters keysAndValuesDo: [ :key :value | 
-		canvas
-			raw: key asString;
-			raw: '=';
-			raw: value asString.
-		anInput parameters keys last = key ifFalse: [ canvas raw: '&' ] ].
-	canvas newLine.
-	canvas raw: '?>'
+    canvas raw: '{!inputFile'.
+    anInput parameters ifNotEmpty: [ canvas raw: '|' ].
+    newParameters := anInput parameters copy.
+    newParameters
+        at: 'path'
+        ifPresent: [ :pathString | | newPath |
+            newPath := (Path from: pathString) withExtension: 'md'.
+            newParameters at: 'path' put: newPath pathString ].
+    newParameters keysAndValuesDo: [ :key :value | 
+        canvas
+            raw: key asString;
+            raw: '=';
+            raw: value asString.
+        anInput parameters keys last = key ifFalse: [ canvas raw: '&' ] ].
+    canvas raw: '!}'
+
 ]
 
 { #category : #'visiting - document' }

--- a/src/Pillar-ExporterMicrodown/PRMicrodownWriterTest.class.st
+++ b/src/Pillar-ExporterMicrodown/PRMicrodownWriterTest.class.st
@@ -53,7 +53,7 @@ PRMicrodownWriterTest >> parser [
 { #category : #running }
 PRMicrodownWriterTest >> setUp [
 	super setUp.
-	parser := MicroDownParser new.
+	parser := MicrodownParser new.
 	writer := PRMicrodownWriter new.
 	builder := MicMicrodownTextualBuilder on: String new writeStream
 

--- a/src/Pillar-ExporterMicrodown/PRPillarToMicrodownConverterTest.class.st
+++ b/src/Pillar-ExporterMicrodown/PRPillarToMicrodownConverterTest.class.st
@@ -54,6 +54,28 @@ Point class >> new
 ]
 
 { #category : #'tests - paragraph list' }
+PRPillarToMicrodownConverterTest >> testInputFile [
+
+    | pillarobject result |
+    pillarobject := pillarParser parse: 
+'${inputFile:path=Chapters/Preface/Preface.pillar}$'.
+    result := writer start: pillarobject ; contents.
+    self assert: result equals: 
+'{!inputFile|path=Chapters/Preface/Preface.md!}'
+]
+
+{ #category : #'tests - paragraph list' }
+PRPillarToMicrodownConverterTest >> testInputFileWithoutExtension [
+
+    | pillarobject result |
+    pillarobject := pillarParser parse: 
+'${inputFile:path=Chapters/Preface/Preface}$'.
+    result := writer start: pillarobject ; contents.
+    self assert: result equals: 
+'{!inputFile|path=Chapters/Preface/Preface.md!}'
+]
+
+{ #category : #'tests - paragraph list' }
 PRPillarToMicrodownConverterTest >> testMathEnvironment [ 
 
 | pillarobject result |

--- a/src/Pillar-ExporterMicrodown/PRPillarToMicrodownConverterTest.class.st
+++ b/src/Pillar-ExporterMicrodown/PRPillarToMicrodownConverterTest.class.st
@@ -54,6 +54,37 @@ Point class >> new
 ]
 
 { #category : #'tests - paragraph list' }
+PRPillarToMicrodownConverterTest >> testMathEnvironment [ 
+
+| pillarobject result |
+    pillarobject := pillarParser parse: 
+'{{{
+[ X = Y + 2 ]
+}}}
+'.
+    result := writer start: pillarobject ; contents.
+    self assert: result equals: 
+'$$
+
+[ X = Y + 2 ]
+
+$$
+
+'
+]
+
+{ #category : #'tests - paragraph list' }
+PRPillarToMicrodownConverterTest >> testMathInline [
+
+| pillarobject result |
+    pillarobject := pillarParser parse: 
+'{{{$X$}}}'.
+    result := writer start: pillarobject ; contents.
+    self assert: result equals: 
+'$X$'
+]
+
+{ #category : #'tests - paragraph list' }
 PRPillarToMicrodownConverterTest >> testNestedLists [
 
 	| pillarobject result |


### PR DESCRIPTION
I have done some change and addition and also for how Oleksandr make math block in pillar, he did it like that : 

{{{
\[ X-2\]
}}}

or

{{{
\begin{align*}
  something
\end{align*}
}}}

so do we change that to : 

{{{$
\[ X-2\]
}}}

or we let this like that ? Also i have talk with Oleksandr about caption/anchor and he told me that he was thinking that he does not make sense to add caption to equations. Do we add a % in order to let us know if we had one perhaps ?