### PR TITLE
Correcting two tests of PRMicrodownWriterTests about language=pharo

### DIFF
--- a/src/Pillar-ExporterMicrodown/PRMicrodownWriterTest.class.st
+++ b/src/Pillar-ExporterMicrodown/PRMicrodownWriterTest.class.st
@@ -112,6 +112,7 @@ PRMicrodownWriterTest >> testCodeBlockCaptionContainsMonospace [
 	mictext := builder
 		           codeblock: self exampleTextMultipleLines
 		           firstLineAssociations: { 
+							  ('language' -> 'pharo').
 				           ('language2' -> 'Pharo').
 				           ('caption' -> '`Color` is cool') };
 		           contents.
@@ -620,7 +621,8 @@ PRMicrodownWriterTest >> testSimpleCodeBlock [
 	Pharo
 	```"
 	
-	self testWithInitialText: (builder codeblock: self exampleTextMultipleLines ; contents)
+	self testWithInitialText: (builder codeblock: self exampleTextMultipleLines 
+												 firstLineAssociations: {('language' -> 'pharo')}; contents)
 ]
 
 { #category : #'tests - code block' }


### PR DESCRIPTION
These two tests was not green because in Microdown we have by default in a MicCodeBlock for arguments "language=pharo" and since it's use in several methods to change the value of language by something else, the more simple thing to do was to add for arguments language=pharo for these two tests in order to get the good result. @Ducasse i let you tell me if it's correct or not from your point of view.

This screenshot below is the methods in MicCodeBlock which actually add the argument language=pharo :
![image](https://user-images.githubusercontent.com/60885865/183655566-1ad28604-02db-4f3a-a583-14bb1fd06081.png)
