### PR TITLE
Pillar for PDF runnable on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,10 @@ $ ls
 LICENSE  README.md  appveyor.yml  archetypes  ==>>build<<==  download.sh  scripts  src
 ```
 
+### Notes for Windows
+- Depending on git's `autocrlf` setting, the downloaded file build.sh and others might end lines with `CRLF`. Ensure that lines end simply with `LF` for script execution.
+- The build.sh script calls the `cygpath` utility. 
+
 ### 2. Setting up the environment
 
 You can then proceed to install that pillar build where you want.
@@ -120,7 +124,7 @@ The simplest way to install `LaTeX` on unix is to install texlive-full in your s
 
 #### Installing `LaTeX` on Windows
 
-Install a `LaTeX` distribution such as [MiKTeX](https://miktex.org/) and install the dependencies specified below using the provided package manager. Then, make sure the bin directory is in your PATH environment variable. For example this could be the following value:
+Install a `LaTeX` distribution such as [MiKTeX](https://miktex.org/) and install the dependencies specified below using the provided package manager. For `MiKTeX`, a perl script environment (e.g. [Strawberry Perl](https://strawberryperl.com)) must be provided separately. Then, make sure the bin directory is in your PATH environment variable. For example this could be the following value: `C:\Users\username\AppData\Local\Programs\MiKTeX\miktex\bin\x64\`.
 
 #### Tailored installation (for non-full lovers)
 Producing pdf documents with Pillar requires a `LaTeX` installation with certain packages.
@@ -186,13 +190,21 @@ Smalltalk globals
 	ifPresent: [ :c | c removeFromSystem ].
 
 ```
-
-The following script can be useful if you develop using the launcher and want to try to execute the image as from a pillar command
-
+### Executing the image as from a pillar command
+The following script can be useful if you develop using the launcher and want to try to execute the image as from a pillar command:
 ```
 /Users/ducasse/Documents/Pharo/vms/100-x64/Pharo.app/Contents/MacOS/Pharo  /Users/ducasse/Documents/Pharo/images/P11-PillarRealReference/P10-PillarRealReference.image clap build pdf index.pillar
 ```
-
+In case of `Windows`, temporary substitute in your image 
+```
+PRTarget >> newProject
+	^ PRProject on: FileSystem workingDirectory
+```
+with the adequate reference to  your target project, e.g.:
+```
+PRTarget >> newProject
+	^ PRProject on: 'C:/cygwin64/home/user/my-book-project' asFileReference
+```
 
 ## History
 

--- a/README.md
+++ b/README.md
@@ -281,5 +281,5 @@ Introduces new template for slides - microdown-mooc (based on extension <!slide.
 ## Old and obsolete documentation
 
 Read the documentation at [https://github.com/SquareBracketAssociates/Booklet-PublishingAPillarBooklet](https://github.com/SquareBracketAssociates/Booklet-PublishingAPillarBooklet).
-Please note that chapter on "Pharo a web Perspective" is obsolete since it refers to Pharo 60.
+Please note that the chapter of the book [Pharo a web Perspective](https://files.pharo.org/books-pdfs/entreprise-pharo/2016-10-06-EnterprisePharo.pdf) dedicated to Pillar is obsolete since it refers to Pharo 60.
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -30,32 +30,18 @@ function get_platform_identifier() {
 __dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 __builddir="$(pwd)/build"
 PHARO_VERSION="${PHARO_VERSION:-130}"
+PHARO="./pharo Pharo.image --no-default-preferences"
 
 rm -rf "${__builddir}" && mkdir -p "${__builddir}" && cd "${__builddir}"
-
-#if command -v pharo >/dev/null 2>&1; then
-#  echo "pharo is in PATH"
-#  PHARO_VM_BIN="pharo"
-#  wget -O - get.pharo.org/64/${PHARO_VERSION} | bash
-#else
-#  echo "pharo not found in PATH"
-#  wget -O - get.pharo.org/64/${PHARO_VERSION}+vm | bash
-#  PHARO_VM_BIN="./pharo"
-#fi
-
 wget -O - get.pharo.org/64/${PHARO_VERSION}+vm | bash
-mv ./pharo ./pharoForPillar
-mv ./pharo-ui ./pharoForPillar-ui
-PHARO_VM_BIN="./pharoForPillar"
-PHARO="$PHARO_VM_BIN Pharo.image --no-default-preferences"
 
 REPOSITORY_PATH=${__dir}/../src
 OS=$(get_platform_identifier)
 if [ "$OS" == "win" ]; then
-    REPOSITORY_PATH=$(cygpath $REPOSITORY_PATH --windows)
+    REPOSITORY_PATH=$(cygpath "$REPOSITORY_PATH" --windows)
 fi
 
-${PHARO} st --quit --save "${__dir}/unload_md.st"
+${PHARO} st --quit --save $(cygpath "${__dir}/unload_md.st" --windows)
 
 ${PHARO} eval --save "Iceberg remoteTypeSelector: #httpsUrl. Metacello new baseline: 'Pillar'; repository: 'gitlocal://${REPOSITORY_PATH}'; load"
 

--- a/src/BaselineOfPillar/BaselineOfPillar.class.st
+++ b/src/BaselineOfPillar/BaselineOfPillar.class.st
@@ -16,10 +16,10 @@ BaselineOfPillar >> baseline: spec [
 				containersPropertyEnvironment: spec;
 				microdown: spec;
 				mustache: spec.
-
-			spec postLoadDoIt: #postload:package:.
+			
 			spec
 				for: #( #unix #osx ) do: [
+						spec postLoadDoIt: #postload:package:.
 						spec
 							package: 'Pillar-Core'
 							with: [ spec requires: #( 'OSSubprocess' 'Microdown' ) ] ];
@@ -141,11 +141,11 @@ BaselineOfPillar >> mustache: spec [
 BaselineOfPillar >> osSubProcess: spec [
 
 	spec
-		for: #( #MacOS #Unix ) do: [
+		for: #( #unix #osx ) do: [
 				spec baseline: 'OSSubprocess' with: [
 							spec repository:
 									'github://pharo-contributions/OSSubprocess:v2.0.0/repository' ] ];
-		for: #Windows do: [
+		for: #windows do: [
 				spec baseline: 'OSWinSubprocess' with: [
 							spec repository:
 									'github://pharo-contributions/OSWinSubprocess:master/repository' ] ]

--- a/src/BaselineOfPillar/BaselineOfPillar.class.st
+++ b/src/BaselineOfPillar/BaselineOfPillar.class.st
@@ -7,61 +7,63 @@ Class {
 
 { #category : 'baselines' }
 BaselineOfPillar >> baseline: spec [
+
 	<baseline>
-	
 	spec for: #common do: [
-		self
-			osSubProcess: spec;
-			chrysal: spec;
-			containersPropertyEnvironment: spec;
-			microdown: spec;
-			mustache: spec.
-			
-		spec postLoadDoIt: #postload:package:.
-		spec
-			package: 'Pillar-Core' 
-				with: [ spec requires: #( 'OSSubprocess' 'Microdown')];
-						
-			package: 'Pillar-ExporterCore' with: [ spec requires: #( 'Pillar-Core' 'ContainersPropertyEnvironment' ) ];
-					
-			"Latex and HTML packages only contain project logic."
-			package: 'Pillar-ExporterLaTeX'
-				with: [ spec requires: #( 'Pillar-ExporterCore' 'Pillar-Core' 'Mustache') ];
-			package: 'Pillar-ExporterHTML'
-				with: [ spec requires: #( 'Pillar-ExporterCore') ];
-			
-			package:  'Pillar-Cli-BookTester' 
-				with: [ spec requires: #('Pillar-Cli' 'Microdown') ];
+			self
+				osSubProcess: spec;
+				chrysal: spec;
+				containersPropertyEnvironment: spec;
+				microdown: spec;
+				mustache: spec.
+
+			spec postLoadDoIt: #postload:package:.
+			spec
+				for: #( #MacOS #Unix ) do: [
+						spec
+							package: 'Pillar-Core'
+							with: [ spec requires: #( 'OSSubprocess' 'Microdown' ) ] ];
+				for: #Windows do: [
+						spec
+							package: 'Pillar-Core'
+							with: [ spec requires: #( 'OSWinSubprocess' 'Microdown' ) ] ];
+				package: 'Pillar-ExporterCore'
+				with: [
+					spec requires: #( 'Pillar-Core' 'ContainersPropertyEnvironment' ) ];
+				"Latex and HTML packages only contain project logic."package:
+					'Pillar-ExporterLaTeX'
+				with: [
+					spec requires:
+							#( 'Pillar-ExporterCore' 'Pillar-Core' 'Mustache' ) ];
+				package: 'Pillar-ExporterHTML'
+				with: [ spec requires: #( 'Pillar-ExporterCore' ) ];
+				package: 'Pillar-Cli-BookTester'
+				with: [ spec requires: #( 'Pillar-Cli' 'Microdown' ) ];
 				"in fact I would like to express that the dependency is to microdown-booktester but I guess
 				that I cannot"
-				
-			
-			package: 'Pillar-Chrysal-Generator' 
-				with: [ spec requires: #( 'Chrysal' ) ];			
-			
-			package: 'Pillar-Cli' 
-				with: [ spec requires: #( 'Pillar-ExporterCore' 'Pillar-Chrysal' 'Pillar-Project') ];
-				
-			package: 'Pillar-Tests-Cli' with: [ spec requires: #( 'Pillar-Cli' ) ];
-			
-			package: 'Pillar-Chrysal' with: [ spec requires: #( 'Pillar-ExporterCore' ) ];
-		
-			package: 'Pillar-Project' with: [ spec requires: #( 'Pillar-Core' ) ];
-		
-			package: 'Pillar-Tests-Project' with: [ spec requires: #( 'Pillar-Project' ) ];
-			package: 'Pillar-Tests-Integration' with: [ spec requires: #( 'Pillar-Project' ) ].
+				package: 'Pillar-Chrysal-Generator'
+				with: [ spec requires: #( 'Chrysal' ) ];
+				package: 'Pillar-Cli' with: [
+						spec requires:
+								#( 'Pillar-ExporterCore' 'Pillar-Chrysal' 'Pillar-Project' ) ];
+				package: 'Pillar-Tests-Cli'
+				with: [ spec requires: #( 'Pillar-Cli' ) ];
+				package: 'Pillar-Chrysal'
+				with: [ spec requires: #( 'Pillar-ExporterCore' ) ];
+				package: 'Pillar-Project'
+				with: [ spec requires: #( 'Pillar-Core' ) ];
+				package: 'Pillar-Tests-Project'
+				with: [ spec requires: #( 'Pillar-Project' ) ];
+				package: 'Pillar-Tests-Integration'
+				with: [ spec requires: #( 'Pillar-Project' ) ].
 
-		spec
-			group: 'All' 
-				with: 
-				#(
-				'Pillar-ExporterLaTeX'
-				'Pillar-ExporterHTML'
-				'Pillar-Tests-Cli' 
-				'Pillar-Tests-Project' 
-				'Pillar-Tests-Integration' );
-			group: 'Core' 
-				with: #( 'Pillar-Core' ) ].
+			spec
+				group: 'All'
+				with:
+					#( 'Pillar-ExporterLaTeX' 'Pillar-ExporterHTML'
+					   'Pillar-Tests-Cli' 'Pillar-Tests-Project'
+					   'Pillar-Tests-Integration' );
+				group: 'Core' with: #( 'Pillar-Core' ) ]
 ]
 
 { #category : 'dependencies' }
@@ -138,7 +140,15 @@ BaselineOfPillar >> mustache: spec [
 { #category : 'dependencies' }
 BaselineOfPillar >> osSubProcess: spec [
 
-	spec baseline: 'OSSubprocess' with: [ spec repository: 'github://pharo-contributions/OSSubprocess:v2.0.0/repository' ]
+	spec
+		for: #( #MacOS #Unix ) do: [
+				spec baseline: 'OSSubprocess' with: [
+							spec repository:
+									'github://pharo-contributions/OSSubprocess:v2.0.0/repository' ] ];
+		for: #Windows do: [
+				spec baseline: 'OSWinSubprocess' with: [
+							spec repository:
+									'github://pharo-contributions/OSWinSubprocess:master/repository' ] ]
 ]
 
 { #category : 'baselines' }
@@ -147,13 +157,4 @@ BaselineOfPillar >> postload: loader package: packageSpec [
 	| list |
 	list := ((Process allInstances select: [ :p | p priority = 70 ]) select: [ :e | '*OSSub*' match: e name ]).
 	list ifNotEmpty: [ :f | f first terminate ]
-]
-
-{ #category : 'dependencies' }
-BaselineOfPillar >> processWrapper: spec [
-
-	spec configuration: 'ProcessWrapper' with: [
-		spec
-			versionString: '1.2';
-			repository: 'http://smalltalkhub.com/mc/hernan/ProcessWrapper/main' ]
 ]

--- a/src/BaselineOfPillar/BaselineOfPillar.class.st
+++ b/src/BaselineOfPillar/BaselineOfPillar.class.st
@@ -19,11 +19,11 @@ BaselineOfPillar >> baseline: spec [
 
 			spec postLoadDoIt: #postload:package:.
 			spec
-				for: #( #MacOS #Unix ) do: [
+				for: #( #unix #osx ) do: [
 						spec
 							package: 'Pillar-Core'
 							with: [ spec requires: #( 'OSSubprocess' 'Microdown' ) ] ];
-				for: #Windows do: [
+				for: #windows do: [
 						spec
 							package: 'Pillar-Core'
 							with: [ spec requires: #( 'OSWinSubprocess' 'Microdown' ) ] ];

--- a/src/BaselineOfPillar/BaselineOfPillar.class.st
+++ b/src/BaselineOfPillar/BaselineOfPillar.class.st
@@ -7,63 +7,61 @@ Class {
 
 { #category : 'baselines' }
 BaselineOfPillar >> baseline: spec [
-
 	<baseline>
+	
 	spec for: #common do: [
-			self
-				osSubProcess: spec;
-				chrysal: spec;
-				containersPropertyEnvironment: spec;
-				microdown: spec;
-				mustache: spec.
+		self
+			osSubProcess: spec;
+			chrysal: spec;
+			containersPropertyEnvironment: spec;
+			microdown: spec;
+			mustache: spec.
 			
-			spec
-				for: #( #unix #osx ) do: [
-						spec postLoadDoIt: #postload:package:.
-						spec
-							package: 'Pillar-Core'
-							with: [ spec requires: #( 'OSSubprocess' 'Microdown' ) ] ];
-				for: #windows do: [
-						spec
-							package: 'Pillar-Core'
-							with: [ spec requires: #( 'OSWinSubprocess' 'Microdown' ) ] ];
-				package: 'Pillar-ExporterCore'
-				with: [
-					spec requires: #( 'Pillar-Core' 'ContainersPropertyEnvironment' ) ];
-				"Latex and HTML packages only contain project logic."package:
-					'Pillar-ExporterLaTeX'
-				with: [
-					spec requires:
-							#( 'Pillar-ExporterCore' 'Pillar-Core' 'Mustache' ) ];
-				package: 'Pillar-ExporterHTML'
-				with: [ spec requires: #( 'Pillar-ExporterCore' ) ];
-				package: 'Pillar-Cli-BookTester'
-				with: [ spec requires: #( 'Pillar-Cli' 'Microdown' ) ];
+		spec postLoadDoIt: #postload:package:.
+		spec
+			package: 'Pillar-Core' 
+				with: [ spec requires: #( 'OSSubprocess' 'OSWinSubprocess' 'Microdown')];
+						
+			package: 'Pillar-ExporterCore' with: [ spec requires: #( 'Pillar-Core' 'ContainersPropertyEnvironment' ) ];
+					
+			"Latex and HTML packages only contain project logic."
+			package: 'Pillar-ExporterLaTeX'
+				with: [ spec requires: #( 'Pillar-ExporterCore' 'Pillar-Core' 'Mustache') ];
+			package: 'Pillar-ExporterHTML'
+				with: [ spec requires: #( 'Pillar-ExporterCore') ];
+			
+			package:  'Pillar-Cli-BookTester' 
+				with: [ spec requires: #('Pillar-Cli' 'Microdown') ];
 				"in fact I would like to express that the dependency is to microdown-booktester but I guess
 				that I cannot"
-				package: 'Pillar-Chrysal-Generator'
-				with: [ spec requires: #( 'Chrysal' ) ];
-				package: 'Pillar-Cli' with: [
-						spec requires:
-								#( 'Pillar-ExporterCore' 'Pillar-Chrysal' 'Pillar-Project' ) ];
-				package: 'Pillar-Tests-Cli'
-				with: [ spec requires: #( 'Pillar-Cli' ) ];
-				package: 'Pillar-Chrysal'
-				with: [ spec requires: #( 'Pillar-ExporterCore' ) ];
-				package: 'Pillar-Project'
-				with: [ spec requires: #( 'Pillar-Core' ) ];
-				package: 'Pillar-Tests-Project'
-				with: [ spec requires: #( 'Pillar-Project' ) ];
-				package: 'Pillar-Tests-Integration'
-				with: [ spec requires: #( 'Pillar-Project' ) ].
+				
+			
+			package: 'Pillar-Chrysal-Generator' 
+				with: [ spec requires: #( 'Chrysal' ) ];			
+			
+			package: 'Pillar-Cli' 
+				with: [ spec requires: #( 'Pillar-ExporterCore' 'Pillar-Chrysal' 'Pillar-Project') ];
+				
+			package: 'Pillar-Tests-Cli' with: [ spec requires: #( 'Pillar-Cli' ) ];
+			
+			package: 'Pillar-Chrysal' with: [ spec requires: #( 'Pillar-ExporterCore' ) ];
+		
+			package: 'Pillar-Project' with: [ spec requires: #( 'Pillar-Core' ) ];
+		
+			package: 'Pillar-Tests-Project' with: [ spec requires: #( 'Pillar-Project' ) ];
+			package: 'Pillar-Tests-Integration' with: [ spec requires: #( 'Pillar-Project' ) ].
 
-			spec
-				group: 'All'
-				with:
-					#( 'Pillar-ExporterLaTeX' 'Pillar-ExporterHTML'
-					   'Pillar-Tests-Cli' 'Pillar-Tests-Project'
-					   'Pillar-Tests-Integration' );
-				group: 'Core' with: #( 'Pillar-Core' ) ]
+		spec
+			group: 'All' 
+				with: 
+				#(
+				'Pillar-ExporterLaTeX'
+				'Pillar-ExporterHTML'
+				'Pillar-Tests-Cli' 
+				'Pillar-Tests-Project' 
+				'Pillar-Tests-Integration' );
+			group: 'Core' 
+				with: #( 'Pillar-Core' ) ].
 ]
 
 { #category : 'dependencies' }
@@ -139,16 +137,19 @@ BaselineOfPillar >> mustache: spec [
 
 { #category : 'dependencies' }
 BaselineOfPillar >> osSubProcess: spec [
+	"From README in https://github.com/pharo-contributions/OSSubprocess:
+	It was decided together with Pharo Consortium that as a first step, we should concentrate on making it work on OSX and Unix. 
+	If the tool proves to be good and accepted, we could, at a second step, try to add Windows support. 
+	If you need Windows support, you can take a look at the https://github.com/pharo-contributions/OSWinSubprocess project."
 
-	spec
-		for: #( #unix #osx ) do: [
-				spec baseline: 'OSSubprocess' with: [
-							spec repository:
-									'github://pharo-contributions/OSSubprocess:v2.0.0/repository' ] ];
-		for: #windows do: [
-				spec baseline: 'OSWinSubprocess' with: [
-							spec repository:
-									'github://pharo-contributions/OSWinSubprocess:master/repository' ] ]
+	"For Unix and OSX"
+	spec baseline: 'OSSubprocess' with: [
+			spec repository:
+				'github://pharo-contributions/OSSubprocess:v2.0.0/repository' ].
+	"For Windows"
+	spec baseline: 'OSWinSubprocess' with: [
+			spec repository:
+				'github://pharo-contributions/OSWinSubprocess:master/repository' ]
 ]
 
 { #category : 'baselines' }

--- a/src/Pillar-ExporterLaTeX/PRPDFDocument.class.st
+++ b/src/Pillar-ExporterLaTeX/PRPDFDocument.class.st
@@ -49,7 +49,7 @@ PRPDFDocument >> executeOnWindowsCommand: command arguments: arguments workingDi
 		           shellCommand: commandString;
 		           runAndWait.
 
-	process exitCode = 0 ifTrue: [
+	process exitCode = 0 ifFalse: [
 		self error: 'command ' , commandString , ' failed' ]
 ]
 

--- a/src/Pillar-ExporterLaTeX/PRPDFDocument.class.st
+++ b/src/Pillar-ExporterLaTeX/PRPDFDocument.class.st
@@ -40,27 +40,17 @@ PRPDFDocument >> executeOnUnixCommand: command arguments: arguments workingDirec
 
 { #category : 'compiling' }
 PRPDFDocument >> executeOnWindowsCommand: command arguments: arguments workingDirectory: aWorkingDirectory [
-	| process success commandString |
-	commandString := 'cd "', aWorkingDirectory, '" && ', command, ' ', (' ' join: arguments).
-	
-	process := ProcessWrapper new.
-	process useStderr; useStdout.
-	success := process startWithShellCommand: commandString.
-	success ifFalse: [
-		self error: 'command ', commandString ,' failed' ].
 
-	success := process waitForExit.
-	success ifFalse: [
-		self error: 'command ', commandString ,' failed' ].
-	
-	Transcript show: process stdoutStream upToEnd.
-	Transcript show: process stderrStream upToEnd.
+	| process commandString |
+	commandString := 'cd "' , aWorkingDirectory , '" && ' , command , ' '
+	                 , (' ' join: arguments).
 
-	process closeStdin.
-	process closeStderr.
+	process := OSWSWinProcess new
+		           shellCommand: commandString;
+		           runAndWait.
 
-	process exitCode = 0 ifFalse: [
-		self error: 'command ', commandString ,' failed' ].
+	process exitCode = 0 ifTrue: [
+		self error: 'command ' , commandString , ' failed' ]
 ]
 
 { #category : 'accessing' }


### PR DESCRIPTION
I substituted ProcessWrapper by OSWinSubProcess and made OSWinSubProcess effective in baseline.
The baseline loads OSSubProcess (OSX, Unix) and OSWinSubProcess together with no platform attributes distinction.

The tests using the launcher for executing the image as from a pillar command were succesful.
Particularly, the Pharo-Graphs booklet could be generated on Windows.
Solely the figures could not be found by TeX.
The cause for this is definitely detected and described in  [Micdown issue 980](https://github.com/pillar-markup/Microdown/issues/980).

Furthermore, I improved the windows part in build.sh:
- accept blanks in REPOSITORY_PATH
- cygpath for unload_md.st

Finally, I complemented Windows notes in README.

I tested on Windows but did not retest on Unix or OSX.